### PR TITLE
feat: add Helm chart and fix gitignore for charts directory

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -68,7 +68,8 @@
     "stretchr",
     "pipefail",
     "slsa",
-    "sigstore"
+    "sigstore",
+    "nindent"
   ],
   "overrides": [
     {

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Publish Chart to GHCR
         id: publish-ghcr
+        # yamllint disable-line rule:line-length
         uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@c465d6571fa0b8be9d551d902955164ea04a00af # main
         with:
           name: ${{ needs.publish.outputs.chart_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@
 *.dll
 *.so
 *.dylib
-fga-sync
-lfx-v2-fga-sync
 
 # Go build artifacts
 *.test

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 extends: default
-
+ignore: |
+  charts/lfx-v2-fga-sync/templates/
 rules:
   line-length:
     max: 120
@@ -14,3 +15,6 @@ rules:
   indentation:
     spaces: 2
     indent-sequences: true
+  braces:
+    min-spaces-inside: -1
+    max-spaces-inside: -1

--- a/charts/lfx-v2-fga-sync/Chart.yaml
+++ b/charts/lfx-v2-fga-sync/Chart.yaml
@@ -1,0 +1,9 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: v2
+name: lfx-v2-fga-sync
+description: LFX Platform V2 FGA Sync chart
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -1,0 +1,62 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.application.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            - name: NATS_URL
+              value: "{{ .Values.nats.url }}"
+            - name: FGA_API_URL
+              value: "{{ .Values.fga.apiUrl }}"
+            - name: FGA_STORE_ID
+              value: "{{ .Values.fga.storeId }}"
+            - name: FGA_MODEL_ID
+              value: "{{ .Values.fga.modelId }}"
+            - name: CACHE_BUCKET
+              value: "{{ .Values.nats.cacheFgaKvBucket.name }}"
+            - name: DEBUG
+              value: "{{ .Values.application.debug }}"
+            - name: USE_CACHE
+              value: "{{ .Values.application.useCache }}"
+          ports:
+            - containerPort: 8080
+              name: web
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: web
+            failureThreshold: 3
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: web
+            failureThreshold: 1
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: web
+            failureThreshold: 30
+            periodSeconds: 1
+          resources:
+            {{toYaml .Values.application.resources | nindent 12}}

--- a/charts/lfx-v2-fga-sync/templates/nats-kv-bucket.yaml
+++ b/charts/lfx-v2-fga-sync/templates/nats-kv-bucket.yaml
@@ -1,0 +1,21 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+{{- if .Values.nats.cacheFgaKvBucket.creation}}
+apiVersion: jetstream.nats.io/v1beta2
+kind: KeyValue
+metadata:
+  name: {{ .Values.nats.cacheFgaKvBucket.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.nats.cacheFgaKvBucket.keep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+spec:
+  bucket: {{ .Values.nats.cacheFgaKvBucket.name }}
+  history: {{ .Values.nats.cacheFgaKvBucket.history }}
+  storage: "{{ .Values.nats.cacheFgaKvBucket.storage }}"
+  maxValueSize: {{ .Values.nats.cacheFgaKvBucket.maxValueSize }}
+  maxBytes: {{ .Values.nats.cacheFgaKvBucket.maxBytes }}
+  compression: {{ .Values.nats.cacheFgaKvBucket.compression }}
+{{- end }}

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -1,0 +1,68 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+
+# image is the configuration for the container image
+image:
+  # repository is the container image repository
+  repository: ghcr.io/linuxfoundation/lfx-v2-fga-sync/lfx-v2-fga-sync
+  # tag is the container image tag (defaults to appVersion if not specified)
+  tag: ""
+  # pullPolicy is the image pull policy
+  pullPolicy: "IfNotPresent"
+
+# nats is the configuration for the NATS server
+nats:
+  # url is the URL of the NATS server
+  url: nats://lfx-platform-nats.lfx.svc.cluster.local:4222
+
+  # cacheFgaKvBucket is the configuration for the KV bucket for storing FGA cache
+  cacheFgaKvBucket:
+    # creation is a boolean to determine if the KV bucket should be created via the helm chart.
+    # set it to false if you want to use an existing KV bucket.
+    creation: true
+    # keep is a boolean to determine if the KV bucket should be preserved during helm uninstall
+    # set it to false if you want the bucket to be deleted when the chart is uninstalled
+    keep: true
+    # name is the name of the KV bucket for storing FGA cache
+    name: fga-sync-cache
+    # history is the number of history entries to keep for the KV bucket
+    history: 20
+    # storage is the storage type for the KV bucket
+    storage: file
+    # maxValueSize is the maximum size of a value in the KV bucket
+    maxValueSize: 10485760 # 10MB
+    # maxBytes is the maximum number of bytes in the KV bucket
+    maxBytes: 1073741824 # 1GB
+    # compression is a boolean to determine if the KV bucket should be compressed
+    compression: true
+
+# fga is the configuration for the OpenFGA server
+# These values come from the lfx-platform helm chart repo:
+# https://github.com/linuxfoundation/lfx-v2-helm/blob/main/docs/openfga.md
+fga:
+  # apiUrl is the URL of the OpenFGA API server
+  apiUrl: http://lfx-platform-openfga.lfx.svc.cluster.local:8080
+  # storeId is the ID of the OpenFGA store
+  storeId: 01K1GTJZW163H839J3YZHD8ZRY
+  # modelId is the ID of the OpenFGA model
+  modelId: 01K1H4TFHDSBCZVZ5EP6HHDWE6
+
+# application is the configuration for the application
+application:
+  # debug is a boolean to determine if the application should run in debug mode
+  debug: false
+  # useCache is a boolean to determine if the application should use the cache
+  # Only turn it off if you are developing locally and are writing to the OpenFGA store
+  # outside of this service (e.g. granting certain access to a test user manually)
+  useCache: true
+  # replicas is the number of pod replicas
+  replicas: 1
+  # resources is the resource configuration for the pods
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "100m"
+    limits:
+      memory: "128Mi"
+      cpu: "500m"


### PR DESCRIPTION
Changes:
 
- Add Helm chart for lfx-v2-fga-sync service deployment
- Include deployment, NATS KV bucket, and values templates
- Fix .gitignore to exclude only root binaries, not charts folder
