### PR TITLE
Update code and chart to support fga-operator 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,9 @@ make gosec         # Run security scanner
 ### Required Environment Variables
 
 - `NATS_URL`: NATS server connection URL (e.g., `nats://localhost:4222`)
-- `FGA_API_URL`: OpenFGA API endpoint (e.g., `http://localhost:8080`)
-- `FGA_STORE_ID`: OpenFGA store ID
-- `FGA_MODEL_ID`: OpenFGA authorization model ID
+- `OPENFGA_API_URL`: OpenFGA API endpoint (e.g., `http://localhost:8080`)
+- `OPENFGA_STORE_ID`: OpenFGA store ID
+- `OPENFGA_AUTH_MODEL_ID`: OpenFGA authorization model ID
 
 ### Optional Environment Variables
 
@@ -169,9 +169,9 @@ Each message type has a dedicated handler function:
 ```bash
 # Set environment variables
 export NATS_URL="nats://localhost:4222"
-export FGA_API_URL="http://localhost:8080"
-export FGA_STORE_ID="01K1GTJZW163H839J3YZHD8ZRY"
-export FGA_MODEL_ID="01K1H4TFHDSBCZVZ5EP6HHDWE6"
+export OPENFGA_API_URL="http://localhost:8080"
+export OPENFGA_STORE_ID="01K1GTJZW163H839J3YZHD8ZRY"
+export OPENFGA_AUTH_MODEL_ID="01K1H4TFHDSBCZVZ5EP6HHDWE6"
 
 # Run the service
 make run
@@ -194,7 +194,7 @@ helm install fga-sync ./charts/lfx-v2-fga-sync \
 
 - **Build failures**: Ensure Go 1.24+ and run `go mod tidy`
 - **NATS connection**: Verify NATS_URL and network connectivity
-- **OpenFGA errors**: Check FGA_API_URL and ensure OpenFGA is healthy
+- **OpenFGA errors**: Check OPENFGA_API_URL and ensure OpenFGA is healthy
 - **Cache issues**: Monitor cache hit rates via `/debug/vars`
 
 ### Debugging

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Dependencies you need but should get from [lfx-v2-helm](https://github.com/linux
    # This assumes you have the lfx-platform chart running
    # from https://github.com/linuxfoundation/lfx-v2-helm/tree/main
    export NATS_URL="nats://lfx-platform-nats.lfx.svc.cluster.local:4222"
-   export FGA_API_URL="http://lfx-platform-openfga.lfx.svc.cluster.local:8080"
-   export FGA_STORE_ID="01K1GTJZW163H839J3YZHD8ZRY"  # Use your actual store ID if you aren't using the lfx-platform chart
-   export FGA_MODEL_ID="01K1H4TFHDSBCZVZ5EP6HHDWE6"   # Use your actual model ID if you aren't using the lfx-platform chart
+   export OPENFGA_API_URL="http://lfx-platform-openfga.lfx.svc.cluster.local:8080"
+   export OPENFGA_STORE_ID="01K1GTJZW163H839J3YZHD8ZRY"  # Use your actual store ID if you aren't using the lfx-platform chart
+   export OPENFGA_AUTH_MODEL_ID="01K1H4TFHDSBCZVZ5EP6HHDWE6"   # Use your actual model ID if you aren't using the lfx-platform chart
    export CACHE_BUCKET="fga-sync-cache"
    export USE_CACHE=true
    export DEBUG=false
@@ -130,9 +130,9 @@ make docker-build
 # Run the container
 docker run -d \
   -e NATS_URL=nats://lfx-platform-nats.lfx.svc.cluster.local:4222 \
-  -e FGA_API_URL=http://lfx-platform-openfga.lfx.svc.cluster.local:8080 \
-  -e FGA_STORE_ID=01K1GTJZW163H839J3YZHD8ZRY \
-  -e FGA_MODEL_ID=01K1H4TFHDSBCZVZ5EP6HHDWE6 \
+  -e OPENFGA_API_URL=http://lfx-platform-openfga.lfx.svc.cluster.local:8080 \
+  -e OPENFGA_STORE_ID=01K1GTJZW163H839J3YZHD8ZRY \
+  -e OPENFGA_AUTH_MODEL_ID=01K1H4TFHDSBCZVZ5EP6HHDWE6 \
   -e CACHE_BUCKET=fga-sync-cache \
   -p 8080:8080 \
   linuxfoundation/lfx-v2-fga-sync:latest
@@ -159,9 +159,9 @@ make helm-install
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | `NATS_URL` | NATS server connection URL | `nats://localhost:4222` | Yes |
-| `FGA_API_URL` | OpenFGA API endpoint | - | Yes |
-| `FGA_STORE_ID` | OpenFGA store ID | - | Yes |
-| `FGA_MODEL_ID` | OpenFGA authorization model ID | - | Yes |
+| `OPENFGA_API_URL` | OpenFGA API endpoint | - | Yes |
+| `OPENFGA_STORE_ID` | OpenFGA store ID | - | Yes |
+| `OPENFGA_AUTH_MODEL_ID` | OpenFGA authorization model ID | - | Yes |
 | `CACHE_BUCKET` | JetStream KeyValue bucket name | `fga-sync-cache` | No |
 | `USE_CACHE` | Whether to try to use cache for access checks | `false` | No |
 | `PORT` | HTTP server port | `8080` | No |

--- a/charts/lfx-v2-fga-sync/Chart.yaml
+++ b/charts/lfx-v2-fga-sync/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-fga-sync
 description: LFX Platform V2 FGA Sync chart
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -34,7 +34,8 @@ spec:
               value: "{{ .Values.nats.url }}"
             - name: OPENFGA_API_URL
               value: "{{ .Values.fga.apiUrl }}"
-            {{- if not (hasKey .Values.deployment.labels "openfga-store") }}
+            {{- $labels := default (dict) .Values.deployment.labels }}
+            {{- if not (hasKey $labels "openfga-store") }}
             - name: OPENFGA_STORE_ID
               value: "{{ .Values.fga.storeId }}"
             - name: OPENFGA_AUTH_MODEL_ID

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -6,6 +6,10 @@ kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.deployment.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.application.replicas }}
   selector:
@@ -15,6 +19,9 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
+        {{- with .Values.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: app
@@ -25,12 +32,14 @@ spec:
           env:
             - name: NATS_URL
               value: "{{ .Values.nats.url }}"
-            - name: FGA_API_URL
+            - name: OPENFGA_API_URL
               value: "{{ .Values.fga.apiUrl }}"
-            - name: FGA_STORE_ID
+            {{- if not (hasKey .Values.deployment.labels "openfga-store") }}
+            - name: OPENFGA_STORE_ID
               value: "{{ .Values.fga.storeId }}"
-            - name: FGA_MODEL_ID
+            - name: OPENFGA_AUTH_MODEL_ID
               value: "{{ .Values.fga.modelId }}"
+            {{- end }}
             - name: CACHE_BUCKET
               value: "{{ .Values.nats.cacheFgaKvBucket.name }}"
             - name: DEBUG

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -14,11 +14,12 @@ image:
 # deployment is the configuration for the deployment
 deployment:
   # labels are additional labels to add to the deployment
-  # When fga-operator is running in the cluster, add the label
-  # 'openfga-store: <store-name>' to automatically populate the
+  # When fga-operator is running in the cluster, adding the label
+  # 'openfga-store: <store-name>' will automatically populate the
   # OPENFGA_STORE_ID and OPENFGA_AUTH_MODEL_ID environment variables
-  # on the pods, overriding fga.storeId and fga.modelId
-  labels: {}
+  # on the pod, overriding fga.storeId and fga.modelId
+  labels:
+    openfga-store: "lfx-core"
   # podLabels are additional labels to add to the pods
   podLabels: {}
 

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -11,6 +11,15 @@ image:
   # pullPolicy is the image pull policy
   pullPolicy: "IfNotPresent"
 
+# deployment is the configuration for the deployment
+deployment:
+  # labels are additional labels to add to the deployment
+  #   if fga-operator is running in the cluster, add the label 'openfga-store: <store-name>' to
+  #   automatically populate the OPENFGA_STORE_ID and OPENFGA_AUTH_MODEL_ID environment variables on the pods
+  labels: {}
+  # podLabels are additional labels to add to the pods
+  podLabels: {}
+
 # nats is the configuration for the NATS server
 nats:
   # url is the URL of the NATS server
@@ -43,9 +52,9 @@ nats:
 fga:
   # apiUrl is the URL of the OpenFGA API server
   apiUrl: http://lfx-platform-openfga.lfx.svc.cluster.local:8080
-  # storeId is the ID of the OpenFGA store
+  # storeId is the ID of the OpenFGA store, ignored if deployment.labels.openfga-store is set and the fga-operator is running
   storeId: 01K1GTJZW163H839J3YZHD8ZRY
-  # modelId is the ID of the OpenFGA model
+  # modelId is the ID of the OpenFGA model, ignored if deployment.labels.openfga-store is set and the fga-operator is running
   modelId: 01K1H4TFHDSBCZVZ5EP6HHDWE6
 
 # application is the configuration for the application

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -14,8 +14,10 @@ image:
 # deployment is the configuration for the deployment
 deployment:
   # labels are additional labels to add to the deployment
-  #   if fga-operator is running in the cluster, add the label 'openfga-store: <store-name>' to
-  #   automatically populate the OPENFGA_STORE_ID and OPENFGA_AUTH_MODEL_ID environment variables on the pods
+  # When fga-operator is running in the cluster, add the label
+  # 'openfga-store: <store-name>' to automatically populate the
+  # OPENFGA_STORE_ID and OPENFGA_AUTH_MODEL_ID environment variables
+  # on the pods, overriding fga.storeId and fga.modelId
   labels: {}
   # podLabels are additional labels to add to the pods
   podLabels: {}
@@ -52,10 +54,14 @@ nats:
 fga:
   # apiUrl is the URL of the OpenFGA API server
   apiUrl: http://lfx-platform-openfga.lfx.svc.cluster.local:8080
-  # storeId is the ID of the OpenFGA store, ignored if deployment.labels.openfga-store is set and the fga-operator is running
-  storeId: 01K1GTJZW163H839J3YZHD8ZRY
-  # modelId is the ID of the OpenFGA model, ignored if deployment.labels.openfga-store is set and the fga-operator is running
-  modelId: 01K1H4TFHDSBCZVZ5EP6HHDWE6
+  # storeId is the ID of the OpenFGA store, ignored if
+  # deployment.labels.openfga-store is set and the fga-operator is
+  # running
+  storeId: ""
+  # modelId is the ID of the OpenFGA model, ignored if
+  # deployment.labels.openfga-store is set and the fga-operator is
+  # running
+  modelId: ""
 
 # application is the configuration for the application
 application:

--- a/fga.go
+++ b/fga.go
@@ -56,9 +56,9 @@ type FgaService struct {
 func connectFga() (IFgaClient, error) {
 	var err error
 	fgaClient, err := NewSdkClient(&ClientConfiguration{
-		ApiUrl:               os.Getenv("FGA_API_URL"),
-		StoreId:              os.Getenv("FGA_STORE_ID"),
-		AuthorizationModelId: os.Getenv("FGA_MODEL_ID"),
+		ApiUrl:               os.Getenv("OPENFGA_API_URL"),
+		StoreId:              os.Getenv("OPENFGA_STORE_ID"),
+		AuthorizationModelId: os.Getenv("OPENFGA_AUTH_MODEL_ID"),
 	})
 	if err != nil {
 		return nil, err

--- a/fga.go
+++ b/fga.go
@@ -55,10 +55,22 @@ type FgaService struct {
 // does not use or support authentication.
 func connectFga() (IFgaClient, error) {
 	var err error
+	fgaURL := os.Getenv("OPENFGA_API_URL")
+	fgaStoreID := os.Getenv("OPENFGA_STORE_ID")
+	fgaAuthModelID := os.Getenv("OPENFGA_AUTH_MODEL_ID")
+	if fgaURL == "" {
+		return nil, fmt.Errorf("OPENFGA_API_URL must be set")
+	}
+	if fgaStoreID == "" {
+		return nil, fmt.Errorf("OPENFGA_STORE_ID must be set")
+	}
+	if fgaAuthModelID == "" {
+		return nil, fmt.Errorf("OPENFGA_AUTH_MODEL_ID must be set")
+	}
 	fgaClient, err := NewSdkClient(&ClientConfiguration{
-		ApiUrl:               os.Getenv("OPENFGA_API_URL"),
-		StoreId:              os.Getenv("OPENFGA_STORE_ID"),
-		AuthorizationModelId: os.Getenv("OPENFGA_AUTH_MODEL_ID"),
+		ApiUrl:               fgaURL,
+		StoreId:              fgaStoreID,
+		AuthorizationModelId: fgaAuthModelID,
 	})
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger.With("url", os.Getenv("FGA_API_URL")).Info("OpenFGA client created")
+	logger.With("url", os.Getenv("OPENFGA_API_URL")).Info("OpenFGA client created")
 
 	// Create HTTP handlers for health checks.
 	createHTTPHandlers()


### PR DESCRIPTION
This commit updates the FGA Sync service to use standard OpenFGA
environment variable names and adds support for the fga-operator in
Kubernetes deployments.

- Renamed `FGA_API_URL` to `OPENFGA_API_URL`
- Renamed `FGA_STORE_ID` to `OPENFGA_STORE_ID`
- Renamed `FGA_MODEL_ID` to `OPENFGA_AUTH_MODEL_ID`

These changes align with OpenFGA's standard naming conventions and
ensure compatibility with the fga-operator.

- Added `deployment.labels` configuration to support custom deployment labels
- Added `deployment.podLabels` configuration for pod-level labels
- Implemented conditional logic to omit `OPENFGA_STORE_ID` and
  `OPENFGA_AUTH_MODEL_ID` environment variables when the `openfga-store`
  label is present (enabling fga-operator injection)
- Updated values.yaml with documentation explaining fga-operator integration

- Updated README.md with new environment variable names in all examples
- Updated CLAUDE.md development documentation with correct variable names
- Added inline comments explaining fga-operator support in values.yaml

When deploying with the fga-operator, users can now add the
`openfga-store: <store-name>` label to the deployment, and the operator
will automatically inject the correct store ID and model ID environment
variables into the pods.

Example:
```yaml
deployment:
  labels:
    openfga-store: my-store
```

Generated with [Cursor](https://cursor.com/)
Assisted by [Claude Code](https://claude.ai/code)

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>