### PR TITLE
added the groups io mailing list handler

### DIFF
--- a/handler_groupsio_mailing_list.go
+++ b/handler_groupsio_mailing_list.go
@@ -1,0 +1,36 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// The fga-sync MailingList.
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
+)
+
+// groupsIOMailingListUpdateAccessHandler handles groups.io MailingList access control updates.
+func (h *HandlerService) groupsIOMailingListUpdateAccessHandler(message INatsMsg) error {
+	ctx := context.Background()
+	logger.With("subject", string(message.Subject())).InfoContext(ctx, "handling groups.io MailingList access control update")
+
+	// Parse the event data.
+	groupsIOMailingList := new(standardAccessStub)
+	err := json.Unmarshal(message.Data(), groupsIOMailingList)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(context.Background(), "event data parse error")
+		return err
+	}
+
+	return h.processStandardAccessUpdate(message, groupsIOMailingList)
+}
+
+// groupsIOMailingListDeleteAllAccessHandler handles groups.io MailingList access control deletions.
+func (h *HandlerService) groupsIOMailingListDeleteAllAccessHandler(message INatsMsg) error {
+	ctx := context.Background()
+	logger.With("subject", string(message.Subject())).InfoContext(ctx, "handling groups.io MailingList access control deletion")
+
+	return h.processDeleteAllAccessMessage(message, constants.ObjectTypeGroupsIOMailingList, "groupsio_MailingList")
+}

--- a/main.go
+++ b/main.go
@@ -360,6 +360,16 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 			handler:     handlerService.groupsIOServiceDeleteAllAccessHandler,
 			description: "groups.io service delete all access",
 		},
+		{
+			subject:     constants.GroupsIOMailingListUpdateAccessSubject,
+			handler:     handlerService.groupsIOMailingListUpdateAccessHandler,
+			description: "groups.io MailingList update access",
+		},
+		{
+			subject:     constants.GroupsIOMailingListDeleteAllAccessSubject,
+			handler:     handlerService.groupsIOMailingListDeleteAllAccessHandler,
+			description: "groups.io MailingList delete all access",
+		},
 	}
 
 	// Subscribe to each subject using the helper function

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -27,12 +27,13 @@ const (
 	RelationMember = "member"
 
 	// Object type prefixes
-	ObjectTypeUser            = "user:"
-	ObjectTypeProject         = "project:"
-	ObjectTypeCommittee       = "committee:"
-	ObjectTypeTeam            = "team:"
-	ObjectTypeMeeting         = "meeting:"
-	ObjectTypeGroupsIOService = "groupsio_service:"
+	ObjectTypeUser                = "user:"
+	ObjectTypeProject             = "project:"
+	ObjectTypeCommittee           = "committee:"
+	ObjectTypeTeam                = "team:"
+	ObjectTypeMeeting             = "meeting:"
+	ObjectTypeGroupsIOService     = "groupsio_service:"
+	ObjectTypeGroupsIOMailingList = "groupsio_mailing_list:"
 
 	// Special user identifiers
 	UserWildcard = "user:*" // Public access (all users)

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -54,6 +54,14 @@ const (
 	// GroupsIOServiceDeleteAllAccessSubject is the subject for the groups.io service access control deletion.
 	// The subject is of the form: lfx.delete_all_access.groupsio_service
 	GroupsIOServiceDeleteAllAccessSubject = "lfx.delete_all_access.groupsio_service"
+
+	// GroupsIOMailingListUpdateAccessSubject is the subject for the groups.io mailing list access control updates.
+	// The subject is of the form: lfx.update_access.groupsio_mailing_list
+	GroupsIOMailingListUpdateAccessSubject = "lfx.update_access.groupsio_mailing_list"
+
+	// GroupsIOMailingListDeleteAllAccessSubject is the subject for the groups.io mailing list access control deletion.
+	// The subject is of the form: lfx.delete_all_access.groupsio_mailing_list
+	GroupsIOMailingListDeleteAllAccessSubject = "lfx.delete_all_access.groupsio_mailing_list"
 )
 
 // NATS queue subjects that the FGA sync service handles messages about.


### PR DESCRIPTION
Issue - https://linuxfoundation.atlassian.net/browse/LFXV2-351
This pull request adds support for handling access control updates and deletions for groups.io MailingList resources in the FGA sync service. The changes introduce new handler functions, constants, and NATS subjects to manage these operations, ensuring that MailingList access events are processed in a consistent manner with other resource types.

**New groups.io MailingList access control support:**

* Added `groupsIOMailingListUpdateAccessHandler` and `groupsIOMailingListDeleteAllAccessHandler` methods to `HandlerService` in `handler_groupsio_mailing_list.go` to process update and delete-all access events for MailingList resources.
* Registered new NATS queue subscriptions in `main.go` for MailingList update and delete-all access events, using the new handlers.

**Constants and subject definitions:**

* Added `ObjectTypeGroupsIOMailingList` to `pkg/constants/fga.go` to represent the MailingList object type.
* Defined new NATS subjects `GroupsIOMailingListUpdateAccessSubject` and `GroupsIOMailingListDeleteAllAccessSubject` in `pkg/constants/nats.go` for MailingList access control events.