### PR TITLE
Bump chart version

### DIFF
--- a/charts/lfx-v2-fga-sync/Chart.yaml
+++ b/charts/lfx-v2-fga-sync/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-fga-sync
 description: LFX Platform V2 FGA Sync chart
 type: application
-version: 0.2.1
+version: 0.2.3
 appVersion: "latest"


### PR DESCRIPTION
This pull request updates the chart version in the Helm chart metadata for `lfx-v2-fga-sync` to reflect a new release.

- Helm chart metadata:
  * Updated the `version` field from `0.2.1` to `0.2.3` in `Chart.yaml` to indicate a new chart release.