### PR TITLE
feat: add GroupsIO member access control support

### DIFF
--- a/handler_groupsio_member.go
+++ b/handler_groupsio_member.go
@@ -1,0 +1,36 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// The fga-sync Member.
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
+)
+
+// groupsIOMemberUpdateAccessHandler handles groups.io Member access control updates.
+func (h *HandlerService) groupsIOMemberUpdateAccessHandler(message INatsMsg) error {
+	ctx := context.Background()
+	logger.With("subject", message.Subject()).InfoContext(ctx, "handling groups.io Member access control update")
+
+	// Parse the event data.
+	groupsIOMember := new(standardAccessStub)
+	err := json.Unmarshal(message.Data(), groupsIOMember)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(context.Background(), "event data parse error")
+		return err
+	}
+
+	return h.processStandardAccessUpdate(message, groupsIOMember)
+}
+
+// groupsIOMemberDeleteAllAccessHandler handles groups.io Member access control deletions.
+func (h *HandlerService) groupsIOMemberDeleteAllAccessHandler(message INatsMsg) error {
+	ctx := context.Background()
+	logger.With("subject", message.Subject()).InfoContext(ctx, "handling groups.io Member access control deletion")
+
+	return h.processDeleteAllAccessMessage(message, constants.ObjectTypeGroupsIOMember, "groupsio_Member")
+}

--- a/main.go
+++ b/main.go
@@ -390,6 +390,16 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 			handler:     handlerService.groupsIOMailingListDeleteAllAccessHandler,
 			description: "groups.io MailingList delete all access",
 		},
+		{
+			subject:     constants.GroupsIOMemberUpdateAccessSubject,
+			handler:     handlerService.groupsIOMemberUpdateAccessHandler,
+			description: "groups.io Member update access",
+		},
+		{
+			subject:     constants.GroupsIOMemberDeleteAllAccessSubject,
+			handler:     handlerService.groupsIOMemberDeleteAllAccessHandler,
+			description: "groups.io Member delete all access",
+		},
 	}
 
 	// Subscribe to each subject using the helper function

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -38,6 +38,7 @@ const (
 	ObjectTypePastMeeting         = "past_meeting:"
 	ObjectTypeGroupsIOService     = "groupsio_service:"
 	ObjectTypeGroupsIOMailingList = "groupsio_mailing_list:"
+	ObjectTypeGroupsIOMember      = "groupsio_member:"
 
 	// Special user identifiers
 	UserWildcard = "user:*" // Public access (all users)

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -78,6 +78,14 @@ const (
 	// GroupsIOMailingListDeleteAllAccessSubject is the subject for the groups.io mailing list access control deletion.
 	// The subject is of the form: lfx.delete_all_access.groupsio_mailing_list
 	GroupsIOMailingListDeleteAllAccessSubject = "lfx.delete_all_access.groupsio_mailing_list"
+
+	// GroupsIOMemberUpdateAccessSubject is the subject for the groups.io member access control updates.
+	// The subject is of the form: lfx.update_access.groupsio_member
+	GroupsIOMemberUpdateAccessSubject = "lfx.update_access.groupsio_member"
+
+	// GroupsIOMemberDeleteAllAccessSubject is the subject for the groups.io member access control deletion.
+	// The subject is of the form: lfx.delete_all_access.groupsio_member
+	GroupsIOMemberDeleteAllAccessSubject = "lfx.delete_all_access.groupsio_member"
 )
 
 // NATS queue subjects that the FGA sync service handles messages about.


### PR DESCRIPTION
Issue - https://linuxfoundation.atlassian.net/browse/LFXV2-352
- Add GroupsIOMember object type constant
- Add NATS subjects for member update/delete operations
- Create handler for GroupsIO member access control
- Register member handlers in subscription config 
Assisted by [Claude Code](https://claude.ai/code)
This pull request adds support for handling access control updates and deletions for groups.io Members in the FGA sync service. It introduces new handler functions, subscribes to new NATS subjects, and updates constants to support these operations.

**New groups.io Member access control support:**

* Added `groupsIOMemberUpdateAccessHandler` and `groupsIOMemberDeleteAllAccessHandler` methods to handle access control updates and deletions for groups.io Members in `handler_groupsio_member.go`.
* Registered new NATS queue subscriptions for `lfx.update_access.groupsio_member` and `lfx.delete_all_access.groupsio_member` subjects in `main.go`.

**Constants updates:**

* Added `ObjectTypeGroupsIOMember` constant for the groups.io member object type in `pkg/constants/fga.go`.
* Added `GroupsIOMemberUpdateAccessSubject` and `GroupsIOMemberDeleteAllAccessSubject` constants for the new NATS subjects in `pkg/constants/nats.go`.