### PR TITLE
[LFXV2-604] Add past meeting artifact access control handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,47 @@ The `artifact_visibility` field determines who can access the summary:
 - `"meeting_hosts"`: Only participants with `host: true` get viewer access
 - `"meeting_participants"`: All participants get viewer access
 
+### Past Meeting Participant Put Message (`lfx.put_participant.past_meeting`)
+
+```json
+{
+  "uid": "participant-123",
+  "past_meeting_uid": "past-meeting-456",
+  "artifact_visibility": "meeting_participants",
+  "username": "user1",
+  "host": true,
+  "is_invited": true,
+  "is_attended": true
+}
+```
+
+When a participant is added or updated:
+1. Updates their relations on the past meeting (host, invitee, attendee)
+2. Syncs their viewer access to all artifacts based on `artifact_visibility`:
+   - `"public"`: No action needed (user:* already grants access)
+   - `"meeting_hosts"`: Adds viewer access only if `host: true`
+   - `"meeting_participants"`: Adds viewer access for all participants
+
+**Important**: If a participant's host status changes (e.g., from participant to host), their artifact access is automatically updated based on the visibility settings.
+
+### Past Meeting Participant Remove Message (`lfx.remove_participant.past_meeting`)
+
+```json
+{
+  "uid": "participant-123",
+  "past_meeting_uid": "past-meeting-456",
+  "artifact_visibility": "meeting_participants",
+  "username": "user1",
+  "host": false,
+  "is_invited": false,
+  "is_attended": false
+}
+```
+
+When a participant is removed:
+1. Removes all their relations from the past meeting
+2. Removes their viewer access from all artifacts (regardless of artifact_visibility)
+
 ## Testing
 
 ### Running Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,81 @@ Simple meeting UID string.
 }
 ```
 
+### Past Meeting Recording Update Message (`lfx.update_access.past_meeting_recording`)
+
+```json
+{
+  "uid": "recording-123",
+  "past_meeting_uid": "past-meeting-456",
+  "artifact_visibility": "public",
+  "participants": [
+    {
+      "username": "user1",
+      "host": true
+    },
+    {
+      "username": "user2",
+      "host": false
+    }
+  ]
+}
+```
+
+The `artifact_visibility` field determines who can access the recording:
+- `"public"`: All users get viewer access
+- `"meeting_hosts"`: Only participants with `host: true` get viewer access
+- `"meeting_participants"`: All participants get viewer access
+
+### Past Meeting Transcript Update Message (`lfx.update_access.past_meeting_transcript`)
+
+```json
+{
+  "uid": "transcript-123",
+  "past_meeting_uid": "past-meeting-456",
+  "artifact_visibility": "meeting_participants",
+  "participants": [
+    {
+      "username": "user1",
+      "host": true
+    },
+    {
+      "username": "user2",
+      "host": false
+    }
+  ]
+}
+```
+
+The `artifact_visibility` field determines who can access the transcript:
+- `"public"`: All users get viewer access
+- `"meeting_hosts"`: Only participants with `host: true` get viewer access
+- `"meeting_participants"`: All participants get viewer access
+
+### Past Meeting Summary Update Message (`lfx.update_access.past_meeting_summary`)
+
+```json
+{
+  "uid": "summary-123",
+  "past_meeting_uid": "past-meeting-456",
+  "artifact_visibility": "meeting_hosts",
+  "participants": [
+    {
+      "username": "user1",
+      "host": true
+    },
+    {
+      "username": "user2",
+      "host": false
+    }
+  ]
+}
+```
+
+The `artifact_visibility` field determines who can access the summary:
+- `"public"`: All users get viewer access
+- `"meeting_hosts"`: Only participants with `host: true` get viewer access
+- `"meeting_participants"`: All participants get viewer access
+
 ## Testing
 
 ### Running Tests

--- a/fga_client.go
+++ b/fga_client.go
@@ -16,6 +16,11 @@ type IFgaClient interface {
 	Read(ctx context.Context, req ClientReadRequest, options ClientReadOptions) (*ClientReadResponse, error)
 	Write(ctx context.Context, req ClientWriteRequest) (*ClientWriteResponse, error)
 	BatchCheck(ctx context.Context, request ClientBatchCheckRequest) (*openfga.BatchCheckResponse, error)
+	ListObjects(
+		ctx context.Context,
+		body ClientListObjectsRequest,
+		options ClientListObjectsOptions,
+	) (*ClientListObjectsResponse, error)
 }
 
 // FgaClient is a wrapper around the OpenFGA client.
@@ -46,4 +51,13 @@ func (c FgaAdapter) Write(
 	req ClientWriteRequest,
 ) (*ClientWriteResponse, error) {
 	return c.OpenFgaClient.Write(ctx).Body(req).Execute()
+}
+
+// ListObjects executes a list objects request.
+func (c FgaAdapter) ListObjects(
+	ctx context.Context,
+	body ClientListObjectsRequest,
+	options ClientListObjectsOptions,
+) (*ClientListObjectsResponse, error) {
+	return c.OpenFgaClient.ListObjects(ctx).Body(body).Options(options).Execute()
 }

--- a/handler_past_meeting_artifact.go
+++ b/handler_past_meeting_artifact.go
@@ -1,0 +1,287 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// The fga-sync service.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
+	"github.com/openfga/go-sdk/client" // Only for client types, not the full SDK
+)
+
+// PastMeetingParticipant represents a participant of a past meeting.
+type PastMeetingParticipant struct {
+	Username string `json:"username"`
+	Host     bool   `json:"host"`
+}
+
+// PastMeetingRecordingAccessMessage is the schema for the data in the message sent to the fga-sync service.
+// These are the fields that the fga-sync service needs in order to update the OpenFGA permissions for recordings.
+type PastMeetingRecordingAccessMessage struct {
+	UID                string                   `json:"uid"`
+	PastMeetingUID     string                   `json:"past_meeting_uid"`
+	ArtifactVisibility string                   `json:"artifact_visibility"`
+	Participants       []PastMeetingParticipant `json:"participants"`
+}
+
+// PastMeetingTranscriptAccessMessage is the schema for the data in the message sent to the fga-sync service.
+// These are the fields that the fga-sync service needs in order to update the OpenFGA permissions for transcripts.
+type PastMeetingTranscriptAccessMessage struct {
+	UID                string                   `json:"uid"`
+	PastMeetingUID     string                   `json:"past_meeting_uid"`
+	ArtifactVisibility string                   `json:"artifact_visibility"`
+	Participants       []PastMeetingParticipant `json:"participants"`
+}
+
+// PastMeetingSummaryAccessMessage is the schema for the data in the message sent to the fga-sync service.
+// These are the fields that the fga-sync service needs in order to update the OpenFGA permissions for summaries.
+type PastMeetingSummaryAccessMessage struct {
+	UID                string                   `json:"uid"`
+	PastMeetingUID     string                   `json:"past_meeting_uid"`
+	ArtifactVisibility string                   `json:"artifact_visibility"`
+	Participants       []PastMeetingParticipant `json:"participants"`
+}
+
+// buildPastMeetingArtifactTuples builds all of the tuples for a past meeting artifact
+// (recording, transcript, or summary).
+func (h *HandlerService) buildPastMeetingArtifactTuples(
+	object string,
+	pastMeetingUID string,
+	artifactVisibility string,
+	participants []PastMeetingParticipant,
+) ([]client.ClientTupleKey, error) {
+	tuples := h.fgaService.NewTupleKeySlice(4)
+
+	// Add the past_meeting relation to associate this artifact with its past meeting
+	if pastMeetingUID != "" {
+		tuples = append(
+			tuples,
+			h.fgaService.TupleKey(constants.ObjectTypePastMeeting+pastMeetingUID, constants.RelationPastMeeting, object),
+		)
+	}
+
+	// Handle artifact visibility
+	switch artifactVisibility {
+	case "public":
+		// Public access - all users get viewer access
+		tuples = append(tuples, h.fgaService.TupleKey(constants.UserWildcard, constants.RelationViewer, object))
+
+	case "meeting_hosts":
+		// Only hosts get viewer access
+		for _, participant := range participants {
+			if participant.Host && participant.Username != "" {
+				tuples = append(
+					tuples,
+					h.fgaService.TupleKey(constants.ObjectTypeUser+participant.Username, constants.RelationViewer, object),
+				)
+			}
+		}
+
+	case "meeting_participants":
+		// All participants get viewer access
+		for _, participant := range participants {
+			if participant.Username != "" {
+				tuples = append(
+					tuples,
+					h.fgaService.TupleKey(constants.ObjectTypeUser+participant.Username, constants.RelationViewer, object),
+				)
+			}
+		}
+
+	default:
+		logger.ErrorContext(context.Background(), "unknown artifact visibility", "visibility", artifactVisibility)
+		return nil, errors.New("unknown artifact visibility: " + artifactVisibility)
+	}
+
+	return tuples, nil
+}
+
+// pastMeetingRecordingUpdateAccessHandler handles past meeting recording access control updates.
+func (h *HandlerService) pastMeetingRecordingUpdateAccessHandler(message INatsMsg) error {
+	ctx := context.Background()
+
+	logger.With("message", string(message.Data())).InfoContext(
+		ctx,
+		"handling past meeting recording access control update",
+	)
+
+	// Parse the event data.
+	recording := new(PastMeetingRecordingAccessMessage)
+	err := json.Unmarshal(message.Data(), recording)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(ctx, "event data parse error")
+		return err
+	}
+
+	// Validate required fields.
+	if recording.PastMeetingUID == "" {
+		logger.ErrorContext(ctx, "past meeting UID not found")
+		return errors.New("past meeting UID not found")
+	}
+
+	object := constants.ObjectTypePastMeetingRecording + recording.UID
+
+	// Build a list of tuples to sync.
+	tuples, err := h.buildPastMeetingArtifactTuples(
+		object,
+		recording.PastMeetingUID,
+		recording.ArtifactVisibility,
+		recording.Participants,
+	)
+	if err != nil {
+		logger.With(errKey, err, "object", object).ErrorContext(ctx, "failed to build past meeting recording tuples")
+		return err
+	}
+
+	tuplesWrites, tuplesDeletes, err := h.fgaService.SyncObjectTuples(ctx, object, tuples)
+	if err != nil {
+		logger.With(errKey, err, "tuples", tuples, "object", object).ErrorContext(ctx, "failed to sync tuples")
+		return err
+	}
+
+	logger.With(
+		"tuples", tuples,
+		"object", object,
+		"writes", tuplesWrites,
+		"deletes", tuplesDeletes,
+	).InfoContext(ctx, "synced tuples")
+
+	if message.Reply() != "" {
+		// Send a reply if an inbox was provided.
+		if err = message.Respond([]byte("OK")); err != nil {
+			logger.With(errKey, err).WarnContext(ctx, "failed to send reply")
+			return err
+		}
+
+		logger.With("object", object).InfoContext(ctx, "sent past meeting recording access control update response")
+	}
+
+	return nil
+}
+
+// pastMeetingTranscriptUpdateAccessHandler handles past meeting transcript access control updates.
+func (h *HandlerService) pastMeetingTranscriptUpdateAccessHandler(message INatsMsg) error {
+	ctx := context.Background()
+
+	logger.With("message", string(message.Data())).InfoContext(
+		ctx,
+		"handling past meeting transcript access control update",
+	)
+
+	// Parse the event data.
+	transcript := new(PastMeetingTranscriptAccessMessage)
+	err := json.Unmarshal(message.Data(), transcript)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(ctx, "event data parse error")
+		return err
+	}
+
+	// Validate required fields.
+	if transcript.PastMeetingUID == "" {
+		logger.ErrorContext(ctx, "past meeting UID not found")
+		return errors.New("past meeting UID not found")
+	}
+
+	object := constants.ObjectTypePastMeetingTranscript + transcript.UID
+
+	// Build a list of tuples to sync.
+	tuples, err := h.buildPastMeetingArtifactTuples(
+		object,
+		transcript.PastMeetingUID,
+		transcript.ArtifactVisibility,
+		transcript.Participants,
+	)
+	if err != nil {
+		logger.With(errKey, err, "object", object).ErrorContext(ctx, "failed to build past meeting transcript tuples")
+		return err
+	}
+
+	tuplesWrites, tuplesDeletes, err := h.fgaService.SyncObjectTuples(ctx, object, tuples)
+	if err != nil {
+		logger.With(errKey, err, "tuples", tuples, "object", object).ErrorContext(ctx, "failed to sync tuples")
+		return err
+	}
+
+	logger.With(
+		"tuples", tuples,
+		"object", object,
+		"writes", tuplesWrites,
+		"deletes", tuplesDeletes,
+	).InfoContext(ctx, "synced tuples")
+
+	if message.Reply() != "" {
+		// Send a reply if an inbox was provided.
+		if err = message.Respond([]byte("OK")); err != nil {
+			logger.With(errKey, err).WarnContext(ctx, "failed to send reply")
+			return err
+		}
+
+		logger.With("object", object).InfoContext(ctx, "sent past meeting transcript access control update response")
+	}
+
+	return nil
+}
+
+// pastMeetingSummaryUpdateAccessHandler handles past meeting summary access control updates.
+func (h *HandlerService) pastMeetingSummaryUpdateAccessHandler(message INatsMsg) error {
+	ctx := context.Background()
+
+	logger.With("message", string(message.Data())).InfoContext(ctx, "handling past meeting summary access control update")
+
+	// Parse the event data.
+	summary := new(PastMeetingSummaryAccessMessage)
+	err := json.Unmarshal(message.Data(), summary)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(ctx, "event data parse error")
+		return err
+	}
+
+	// Validate required fields.
+	if summary.PastMeetingUID == "" {
+		logger.ErrorContext(ctx, "past meeting UID not found")
+		return errors.New("past meeting UID not found")
+	}
+
+	object := constants.ObjectTypePastMeetingSummary + summary.UID
+
+	// Build a list of tuples to sync.
+	tuples, err := h.buildPastMeetingArtifactTuples(
+		object,
+		summary.PastMeetingUID,
+		summary.ArtifactVisibility,
+		summary.Participants,
+	)
+	if err != nil {
+		logger.With(errKey, err, "object", object).ErrorContext(ctx, "failed to build past meeting summary tuples")
+		return err
+	}
+
+	tuplesWrites, tuplesDeletes, err := h.fgaService.SyncObjectTuples(ctx, object, tuples)
+	if err != nil {
+		logger.With(errKey, err, "tuples", tuples, "object", object).ErrorContext(ctx, "failed to sync tuples")
+		return err
+	}
+
+	logger.With(
+		"tuples", tuples,
+		"object", object,
+		"writes", tuplesWrites,
+		"deletes", tuplesDeletes,
+	).InfoContext(ctx, "synced tuples")
+
+	if message.Reply() != "" {
+		// Send a reply if an inbox was provided.
+		if err = message.Respond([]byte("OK")); err != nil {
+			logger.With(errKey, err).WarnContext(ctx, "failed to send reply")
+			return err
+		}
+
+		logger.With("object", object).InfoContext(ctx, "sent past meeting summary access control update response")
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -390,6 +390,21 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 			handler:     handlerService.groupsIOMailingListDeleteAllAccessHandler,
 			description: "groups.io MailingList delete all access",
 		},
+		{
+			subject:     constants.PastMeetingRecordingUpdateAccessSubject,
+			handler:     handlerService.pastMeetingRecordingUpdateAccessHandler,
+			description: "past meeting recording update access",
+		},
+		{
+			subject:     constants.PastMeetingTranscriptUpdateAccessSubject,
+			handler:     handlerService.pastMeetingTranscriptUpdateAccessHandler,
+			description: "past meeting transcript update access",
+		},
+		{
+			subject:     constants.PastMeetingSummaryUpdateAccessSubject,
+			handler:     handlerService.pastMeetingSummaryUpdateAccessHandler,
+			description: "past meeting summary update access",
+		},
 	}
 
 	// Subscribe to each subject using the helper function

--- a/mock.go
+++ b/mock.go
@@ -51,6 +51,17 @@ func (m *MockFgaClient) BatchCheck(
 	return args.Get(0).(*openfga.BatchCheckResponse), args.Error(1)
 }
 
+// ListObjects implements the IFgaClient interface
+func (m *MockFgaClient) ListObjects(
+	ctx context.Context,
+	body ClientListObjectsRequest,
+	options ClientListObjectsOptions,
+) (*ClientListObjectsResponse, error) {
+	args := m.Called(ctx, body, options)
+	//nolint:errcheck // the error is passed through to the caller
+	return args.Get(0).(*ClientListObjectsResponse), args.Error(1)
+}
+
 // MockNatsMsg is a mock implementation of the INatsMsg interface
 type MockNatsMsg struct {
 	mock.Mock

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -25,19 +25,23 @@ const (
 	RelationAttendee    = "attendee"
 	RelationInvitee     = "invitee"
 	RelationMeeting     = "meeting"
+	RelationPastMeeting = "past_meeting"
 
 	// Team relations
 	RelationMember = "member"
 
 	// Object type prefixes
-	ObjectTypeUser                = "user:"
-	ObjectTypeProject             = "project:"
-	ObjectTypeCommittee           = "committee:"
-	ObjectTypeTeam                = "team:"
-	ObjectTypeMeeting             = "meeting:"
-	ObjectTypePastMeeting         = "past_meeting:"
-	ObjectTypeGroupsIOService     = "groupsio_service:"
-	ObjectTypeGroupsIOMailingList = "groupsio_mailing_list:"
+	ObjectTypeUser                  = "user:"
+	ObjectTypeProject               = "project:"
+	ObjectTypeCommittee             = "committee:"
+	ObjectTypeTeam                  = "team:"
+	ObjectTypeMeeting               = "meeting:"
+	ObjectTypePastMeeting           = "past_meeting:"
+	ObjectTypePastMeetingRecording  = "past_meeting_recording:"
+	ObjectTypePastMeetingTranscript = "past_meeting_transcript:"
+	ObjectTypePastMeetingSummary    = "past_meeting_summary:"
+	ObjectTypeGroupsIOService       = "groupsio_service:"
+	ObjectTypeGroupsIOMailingList   = "groupsio_mailing_list:"
 
 	// Special user identifiers
 	UserWildcard = "user:*" // Public access (all users)

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -78,6 +78,18 @@ const (
 	// GroupsIOMailingListDeleteAllAccessSubject is the subject for the groups.io mailing list access control deletion.
 	// The subject is of the form: lfx.delete_all_access.groupsio_mailing_list
 	GroupsIOMailingListDeleteAllAccessSubject = "lfx.delete_all_access.groupsio_mailing_list"
+
+	// PastMeetingRecordingUpdateAccessSubject is the subject for the past meeting recording access control updates.
+	// The subject is of the form: lfx.update_access.past_meeting_recording
+	PastMeetingRecordingUpdateAccessSubject = "lfx.update_access.past_meeting_recording"
+
+	// PastMeetingTranscriptUpdateAccessSubject is the subject for the past meeting transcript access control updates.
+	// The subject is of the form: lfx.update_access.past_meeting_transcript
+	PastMeetingTranscriptUpdateAccessSubject = "lfx.update_access.past_meeting_transcript"
+
+	// PastMeetingSummaryUpdateAccessSubject is the subject for the past meeting summary access control updates.
+	// The subject is of the form: lfx.update_access.past_meeting_summary
+	PastMeetingSummaryUpdateAccessSubject = "lfx.update_access.past_meeting_summary"
 )
 
 // NATS queue subjects that the FGA sync service handles messages about.


### PR DESCRIPTION
## Summary
Add handlers for past meeting artifact (recording, transcript, summary) access control with automatic participant synchronization.

## Ticket
https://linuxfoundation.atlassian.net/browse/LFXV2-604

## Changes
- **Add artifact access control handlers**: Created handlers for `lfx.update_access.past_meeting_recording`, `lfx.update_access.past_meeting_transcript`, and `lfx.update_access.past_meeting_summary` NATS messages
- **Automatic participant sync**: When participants are added/removed/updated, their artifact viewer access is automatically synced based on artifact visibility settings
- **OpenFGA List Objects integration**: Implemented `ListObjectsByUserAndRelation()` using OpenFGA's List Objects API for efficient querying
- **Support three visibility modes**:
  - `public`: All users get viewer access via `user:*`
  - `meeting_hosts`: Only hosts get viewer access  
  - `meeting_participants`: All participants get viewer access
- **Handle role transitions**: Properly updates access when participants change roles (e.g., participant → host)

## Technical Details
- Added `ListObjects` support to FGA client interface and adapter
- Added `syncArtifactViewerAccessForParticipant()` helper to update artifact access
- Updated `putPastMeetingParticipant()` and `removePastMeetingParticipant()` to sync artifacts
- Added comprehensive documentation in CLAUDE.md with message examples
- All tests passing ✅

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Code quality checks pass (`make check`)
- [ ] Manual testing with NATS messages for all three artifact types
- [ ] Verify participant add/remove syncs artifact access correctly
- [ ] Verify role transitions update artifact access appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)