### PR TITLE
[LFXV2-920] Committee member visibility - Conditional Relation

### DIFF
--- a/charts/lfx-v2-fga-sync/Chart.yaml
+++ b/charts/lfx-v2-fga-sync/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-fga-sync
 description: LFX Platform V2 FGA Sync chart
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "latest"

--- a/handler_committee.go
+++ b/handler_committee.go
@@ -20,6 +20,7 @@ type committeeStub struct {
 	Public     bool                `json:"public"`
 	Relations  map[string][]string `json:"relations"`
 	References map[string]string   `json:"references"`
+	Self       []string            `json:"self"`
 }
 
 // committeeUpdateAccessHandler handles committee access control updates.
@@ -72,7 +73,12 @@ func (h *HandlerService) committeeUpdateAccessHandler(message INatsMsg) error {
 		}
 	}
 
-	tuplesWrites, tuplesDeletes, err := h.fgaService.SyncObjectTuples(ctx, object, tuples)
+	// self relations
+	for _, relation := range committee.Self {
+		tuples = append(tuples, h.fgaService.TupleKey(object, relation, object))
+	}
+
+	tuplesWrites, tuplesDeletes, err := h.fgaService.SyncObjectTuples(ctx, object, tuples, "member")
 	if err != nil {
 		logger.With(errKey, err, "tuples", tuples, "object", object).ErrorContext(ctx, "failed to sync tuples")
 		return err

--- a/handler_committee.go
+++ b/handler_committee.go
@@ -80,7 +80,7 @@ func (h *HandlerService) committeeUpdateAccessHandler(message INatsMsg) error {
 		tuples = append(tuples, h.fgaService.TupleKey(object, relation, object))
 	}
 
-	tuplesWrites, tuplesDeletes, err := h.fgaService.SyncObjectTuples(ctx, object, tuples, "member")
+	tuplesWrites, tuplesDeletes, err := h.fgaService.SyncObjectTuples(ctx, object, tuples, constants.RelationMember)
 	if err != nil {
 		logger.With(errKey, err, "tuples", tuples, "object", object).ErrorContext(ctx, "failed to sync tuples")
 		return err

--- a/handler_committee.go
+++ b/handler_committee.go
@@ -73,7 +73,9 @@ func (h *HandlerService) committeeUpdateAccessHandler(message INatsMsg) error {
 		}
 	}
 
-	// self relations
+	// Add self relations where the committee object is both the subject and the resource.
+	// These are used for intrinsic roles or capabilities of the committee itself (for example,
+	// roles that are defined on the committee object in the OpenFGA schema rather than on users).
 	for _, relation := range committee.Self {
 		tuples = append(tuples, h.fgaService.TupleKey(object, relation, object))
 	}


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-920

This pull request introduces an update to the committee access control logic, primarily by adding support for "self" relations in the committee data structure and ensuring these are synchronized with the access control service. The changes improve flexibility in representing committee relationships and update the tuple synchronization logic accordingly.

Relates to
* https://github.com/linuxfoundation/lfx-v2-committee-service/pull/54 (test evidence in this PR)