### PR TITLE
Fix batch check error responses being cached as access denied

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -114,7 +114,8 @@
         "otelhttp",
         "tracecontext",
         "traceparent",
-        "tracestate"
+        "tracestate",
+        "INTERNALERRORCODE"
       ]
     },
     {

--- a/fga.go
+++ b/fga.go
@@ -28,6 +28,11 @@ import (
 // Note: all OpenFGA SDK calls are kept in the same file due to the namespace
 // pollution which is the recommended way of using this SDK.
 
+const (
+	// trueString is used for cache values representing allowed access
+	trueString = "true"
+)
+
 var (
 	cacheHits       *expvar.Int
 	cacheStaleHits  *expvar.Int
@@ -274,7 +279,7 @@ func (s FgaService) SyncObjectTuples(
 				// access relations. This happens asynchronously so we are not checking
 				// for errors or logging anything.
 				//nolint:errcheck // This happens asynchronously so we are not checking for errors.
-				_, _ = s.cacheBucket.PutString(timeoutCtx, cacheKey, "true")
+				_, _ = s.cacheBucket.PutString(timeoutCtx, cacheKey, trueString)
 			}(cacheKey)
 		}
 	}

--- a/fga.go
+++ b/fga.go
@@ -535,16 +535,36 @@ func (s FgaService) appendToMessage(
 			continue
 		}
 		relationKey := req.Object + "#" + req.Relation + "@" + req.User
+
+		// Need a bool to handle whether or not a response should be cached
+		// This is needed since it may be an error and not a valid response, but we
+		// still need to return not allowed and not cache it
+		shouldCache := true
+		// Check if the response contains an error (e.g., timeout, deadline exceeded)
+		// and skip caching/responding with error results.
+		if resp.HasError() {
+			checkErr := resp.GetError()
+			logger.With(
+				"correlation_id", correlationID,
+				"relation_key", relationKey,
+				"error_code", checkErr.GetInternalError(),
+				"error_message", checkErr.GetMessage(),
+			).WarnContext(ctx, "batch check returned error for tuple, skipping cache")
+			shouldCache = false
+		}
+
 		allowed := strconv.FormatBool(resp.GetAllowed())
 
 		// Append the result to our response message.
 		message = append(message, []byte(relationKey+"\t"+allowed+"\n")...)
 
 		// Cache the result.
-		cacheKey := "rel." + cacheKeyEncoder.EncodeToString([]byte(relationKey))
-		_, err := s.cacheBucket.Put(ctx, cacheKey, []byte(allowed))
-		if err != nil {
-			logger.With(errKey, err).ErrorContext(ctx, "failed to cache relation")
+		if shouldCache {
+			cacheKey := "rel." + cacheKeyEncoder.EncodeToString([]byte(relationKey))
+			_, err := s.cacheBucket.Put(ctx, cacheKey, []byte(allowed))
+			if err != nil {
+				logger.With(errKey, err).ErrorContext(ctx, "failed to cache relation")
+			}
 		}
 	}
 

--- a/handler_access_test.go
+++ b/handler_access_test.go
@@ -160,6 +160,67 @@ func TestAccessCheckHandler(t *testing.T) {
 			expectedError:  true,
 			expectedCalled: true,
 		},
+		{
+			name:         "batch check with timeout errors should not cache errors",
+			messageData:  []byte("project:123#writer@user:456\nproject:789#viewer@user:789\nproject:999#admin@user:999"),
+			replySubject: "reply.subject",
+			setupMocks: func(service HandlerService, msg *MockNatsMsg) {
+				// All checks should be in the response, but errors return false
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					response := string(data)
+					// Should contain all three check results
+					// Error checks return false, successful check returns true
+					return strings.Contains(response, "project:123#writer@user:456\tfalse") &&
+						strings.Contains(response, "project:789#viewer@user:789\ttrue") &&
+						strings.Contains(response, "project:999#admin@user:999\tfalse")
+				})).Return(nil).Once()
+
+				// Create result map with mixed success and error responses
+				resultMap := make(map[string]openfga.BatchCheckSingleResult, 3)
+
+				// First check: deadline_exceeded error
+				deadlineMsg := "context deadline exceeded"
+				deadlineErr := openfga.INTERNALERRORCODE_DEADLINE_EXCEEDED
+				resultMap["1"] = openfga.BatchCheckSingleResult{
+					Error: &openfga.CheckError{
+						InternalError: &deadlineErr,
+						Message:       &deadlineMsg,
+					},
+				}
+
+				// Second check: successful
+				resultMap["2"] = openfga.BatchCheckSingleResult{
+					Allowed: openfga.PtrBool(true),
+				}
+
+				// Third check: internal_error
+				internalMsg := "internal error"
+				internalErr := openfga.INTERNALERRORCODE_INTERNAL_ERROR
+				resultMap["3"] = openfga.BatchCheckSingleResult{
+					Error: &openfga.CheckError{
+						InternalError: &internalErr,
+						Message:       &internalMsg,
+					},
+				}
+
+				service.fgaService.client.(*MockFgaClient).On("BatchCheck", mock.Anything, mock.Anything).Return(&openfga.BatchCheckResponse{
+					Result: &resultMap,
+				}, nil)
+
+				// Mock cache operations
+				service.fgaService.cacheBucket.(*MockKeyValue).On("Get", mock.Anything, "inv").Return(nil, jetstream.ErrKeyNotFound)
+				service.fgaService.cacheBucket.(*MockKeyValue).On("Get", mock.Anything, mock.AnythingOfType("string")).Return(nil, jetstream.ErrKeyNotFound)
+
+				// IMPORTANT: Only the successful check (correlation_id=2) should be cached
+				// The error responses should NOT trigger cache Put calls
+				service.fgaService.cacheBucket.(*MockKeyValue).On("Put", mock.Anything, mock.AnythingOfType("string"), mock.MatchedBy(func(data []byte) bool {
+					// Only "true" should be cached (from the successful check)
+					return string(data) == "true"
+				})).Return(uint64(0), nil).Once()
+			},
+			expectedError:  false,
+			expectedCalled: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func init() {
 		cacheBucketName = "fga-sync-cache"
 	}
 	useCacheStr := os.Getenv("USE_CACHE")
-	if useCacheStr == "true" {
+	if useCacheStr == trueString {
 		useCache = true
 	}
 }


### PR DESCRIPTION
OpenFGA batch check can return error responses (e.g., deadline_exceeded, internal_error) when timing out or encountering transient failures. These errors were being cached as "allowed=false" results, causing legitimate access requests to be permanently denied until cache expiration.

The appendToMessage function now checks for errors using HasError() before caching results. Error responses are logged and not cached, ensuring only successful authorization checks (both allowed and denied) are cached. A false value is still returned ensuring no one incorrectly gets access to the resource.

Added test case verifying that mixed success/error responses are handled correctly and only successful results trigger cache operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)