### PR TITLE
[LFXV2-1211] Add pod annotations support

### DIFF
--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       app: {{ .Chart.Name }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Chart.Name }}
         {{- with .Values.deployment.podLabels }}

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -11,6 +11,10 @@ image:
   # pullPolicy is the image pull policy
   pullPolicy: "IfNotPresent"
 
+# podAnnotations are additional annotations applied to the pod template.
+# Example:
+#   prometheus.io/scrape: "true"
+#   prometheus.io/port: "8080"
 podAnnotations: {}
 
 # deployment is the configuration for the deployment

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -11,6 +11,8 @@ image:
   # pullPolicy is the image pull policy
   pullPolicy: "IfNotPresent"
 
+podAnnotations: {}
+
 # deployment is the configuration for the deployment
 deployment:
   # labels are additional labels to add to the deployment


### PR DESCRIPTION
## Summary
- Add `podAnnotations` value to Helm chart (default empty)
- Update deployment template to render pod-level annotations

Note: This service already supports `deployment.podLabels` for pod labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)