### PR TITLE
[LFXV2-1381] feat(scripts): add audit script for listing recent OpenFGA tuple changes

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,19 @@
+# scripts
+
+Utility scripts for operating and maintaining the fga-sync service.
+
+## Structure
+
+```
+scripts/
+└── audit/                          # Inspect and verify authorization state
+    └── list-tuple-changes/         # List recent tuple writes and deletes across the store
+```
+
+## Folders
+
+### `audit/`
+
+Scripts for inspecting and verifying the state of authorization data in OpenFGA.
+Use these when you need to understand what tuples exist, what has changed recently,
+or to diagnose unexpected access control behavior.

--- a/scripts/audit/list-tuple-changes/README.md
+++ b/scripts/audit/list-tuple-changes/README.md
@@ -22,7 +22,7 @@ go run ./scripts/audit/list-tuple-changes [flags]
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `-since` | `1h` | How far back to look for changes. Accepts Go duration strings: `30m`, `2h`, `24h`, `7d`, etc. |
+| `-since` | `1h` | How far back to look for changes. Accepts Go duration strings: `30m`, `2h`, `24h`, `168h`, etc. |
 | `-type` | _(all types)_ | Filter results to a specific object type (e.g. `project`, `committee`, `meeting`). |
 | `-all-pages` | `false` | When set, automatically pages through all results instead of stopping after the first page. |
 
@@ -59,3 +59,7 @@ Each line contains:
 - **Timestamp** — local time when the change was recorded
 - **Operation** — `WRITE` (tuple created) or `DELETE` (tuple removed)
 - **Tuple** — in `object#relation@user` format
+
+## API Reference
+
+This script uses the OpenFGA [ReadChanges](https://openfga.dev/api/service#/Relationship%20Tuples/ReadChanges) API endpoint.

--- a/scripts/audit/list-tuple-changes/README.md
+++ b/scripts/audit/list-tuple-changes/README.md
@@ -1,0 +1,61 @@
+# list-tuple-changes
+
+CLI tool for inspecting recent OpenFGA tuple changes across the entire store.
+
+## Prerequisites
+
+The following environment variables must be set:
+
+```bash
+export OPENFGA_API_URL="http://localhost:8080"
+export OPENFGA_STORE_ID="<your-store-id>"
+export OPENFGA_AUTH_MODEL_ID="<your-auth-model-id>"
+```
+
+## Usage
+
+```bash
+go run ./scripts/audit/list-tuple-changes [flags]
+```
+
+## Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-since` | `1h` | How far back to look for changes. Accepts Go duration strings: `30m`, `2h`, `24h`, `7d`, etc. |
+| `-type` | _(all types)_ | Filter results to a specific object type (e.g. `project`, `committee`, `meeting`). |
+| `-all-pages` | `false` | When set, automatically pages through all results instead of stopping after the first page. |
+
+## Examples
+
+```bash
+# Show all changes from the last hour (default)
+go run ./scripts/audit/list-tuple-changes
+
+# Show changes from the last 24 hours
+go run ./scripts/audit/list-tuple-changes -since 24h
+
+# Show only project tuple changes from the last 30 minutes
+go run ./scripts/audit/list-tuple-changes -since 30m -type project
+
+# Show all committee changes from the last week, paginating through everything
+go run ./scripts/audit/list-tuple-changes -since 168h -type committee -all-pages
+```
+
+## Output
+
+```text
+Fetching tuple changes since 2026-04-02 09:00:00 (type: project)
+
+[2026-04-02 09:45:12] WRITE     project:abc-123#writer@user:456
+[2026-04-02 09:46:01] DELETE    project:abc-123#viewer@user:789
+[2026-04-02 09:50:33] WRITE     project:xyz-789#viewer@user:*
+
+Total changes: 3
+```
+
+Each line contains:
+
+- **Timestamp** — local time when the change was recorded
+- **Operation** — `WRITE` (tuple created) or `DELETE` (tuple removed)
+- **Tuple** — in `object#relation@user` format

--- a/scripts/audit/list-tuple-changes/main.go
+++ b/scripts/audit/list-tuple-changes/main.go
@@ -1,0 +1,117 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// list-tuple-changes is a CLI tool for inspecting recent OpenFGA tuple changes.
+//
+// Usage:
+//
+//	go run ./scripts/audit/list-tuple-changes [flags]
+//
+// Flags:
+//
+//	-since duration   Show changes from the last duration (default: 1h). Examples: 30m, 2h, 24h
+//	-type string      Filter by object type (e.g. project, committee, meeting). Empty = all types.
+//	-all-pages        Fetch all pages of results (default: false, stops after first page)
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	. "github.com/openfga/go-sdk/client"
+)
+
+func main() {
+	since := flag.Duration("since", time.Hour, "Show changes from the last duration (e.g. 30m, 2h, 24h)")
+	objectType := flag.String("type", "", "Filter by object type (e.g. project, committee, meeting). Empty = all types.")
+	allPages := flag.Bool("all-pages", false, "Fetch all pages of results")
+	flag.Parse()
+
+	fgaURL := os.Getenv("OPENFGA_API_URL")
+	fgaStoreID := os.Getenv("OPENFGA_STORE_ID")
+	fgaAuthModelID := os.Getenv("OPENFGA_AUTH_MODEL_ID")
+
+	if fgaURL == "" {
+		log.Fatal("OPENFGA_API_URL environment variable is required")
+	}
+	if fgaStoreID == "" {
+		log.Fatal("OPENFGA_STORE_ID environment variable is required")
+	}
+	if fgaAuthModelID == "" {
+		log.Fatal("OPENFGA_AUTH_MODEL_ID environment variable is required")
+	}
+
+	client, err := NewSdkClient(&ClientConfiguration{
+		ApiUrl:               fgaURL,
+		StoreId:              fgaStoreID,
+		AuthorizationModelId: fgaAuthModelID,
+		HTTPClient:           &http.Client{Timeout: 30 * time.Second},
+	})
+	if err != nil {
+		log.Fatalf("failed to create OpenFGA client: %v", err)
+	}
+
+	ctx := context.Background()
+	startTime := time.Now().Add(-*since)
+
+	fmt.Printf("Fetching tuple changes since %s", startTime.Format(time.RFC3339))
+	if *objectType != "" {
+		fmt.Printf(" (type: %s)", *objectType)
+	}
+	fmt.Println()
+	fmt.Println()
+
+	body := ClientReadChangesRequest{
+		StartTime: startTime,
+	}
+	if *objectType != "" {
+		body.Type = *objectType
+	}
+
+	pageSizeInt32 := int32(100)
+	options := ClientReadChangesOptions{
+		PageSize: &pageSizeInt32,
+	}
+
+	totalChanges := 0
+	page := 0
+	var prevToken string
+
+	for {
+		page++
+		resp, err := client.ReadChanges(ctx).Body(body).Options(options).Execute()
+		if err != nil {
+			log.Fatalf("failed to read changes (page %d): %v", page, err)
+		}
+
+		for _, change := range resp.Changes {
+			totalChanges++
+			fmt.Printf("[%s] %-8s  %s#%s@%s\n",
+				change.Timestamp.Local().Format("2006-01-02 15:04:05"),
+				change.Operation,
+				change.TupleKey.Object,
+				change.TupleKey.Relation,
+				change.TupleKey.User,
+			)
+		}
+
+		nextToken := ""
+		if resp.ContinuationToken != nil {
+			nextToken = *resp.ContinuationToken
+		}
+
+		// OpenFGA returns the same token when there are no more changes.
+		if !*allPages || nextToken == "" || nextToken == prevToken {
+			break
+		}
+		prevToken = nextToken
+		options.ContinuationToken = &nextToken
+	}
+
+	fmt.Printf("\nTotal changes: %d\n", totalChanges)
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/audit/list-tuple-changes`, a CLI tool that uses the OpenFGA `ReadChanges` API to inspect recent tuple writes and deletes across the entire store
- Establishes the `scripts/` directory convention with an `audit/` subfolder for future operational tooling
- Includes a top-level `scripts/README.md` describing the folder structure and purpose of each category

## Usage

```bash
# Set required env vars
export OPENFGA_API_URL="http://localhost:8080"
export OPENFGA_STORE_ID="<your-store-id>"
export OPENFGA_AUTH_MODEL_ID="<your-auth-model-id>"

# Show all changes from the last hour (default)
go run ./scripts/audit/list-tuple-changes

# Show only project tuple changes from the last 30 minutes
go run ./scripts/audit/list-tuple-changes -since 30m -type project

# Show all committee changes from the last week, paginating through all results
go run ./scripts/audit/list-tuple-changes -since 168h -type committee -all-pages
```

**Example output:**

```text
Fetching tuple changes since 2026-04-02 09:00:00 (type: v1_past_meeting)

[2026-04-02 10:20:46] TUPLE_OPERATION_WRITE  v1_past_meeting:1712585189215-1712534400000#meeting@v1_meeting:1712585189215
[2026-04-02 10:20:46] TUPLE_OPERATION_WRITE  v1_past_meeting:1712585189215-1712534400000#project@project:a27394a3-7a6c-4d0f-9e0f-692d8753924f
[2026-04-02 10:20:46] TUPLE_OPERATION_DELETE  v1_past_meeting:91360846835-1704361800000#viewer@user:*

Total changes: 3
```

## Ticket

[LFXV2-1381](https://linuxfoundation.atlassian.net/browse/LFXV2-1381)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1381]: https://linuxfoundation.atlassian.net/browse/LFXV2-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ