### PR TITLE
Add deployment annotation for Backstage ingestion

### DIFF
--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -6,11 +6,11 @@ kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.deployment.labels }}
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- with (omit (.Values.deployment.labels | default dict) "app.kubernetes.io/name") }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   replicas: {{ .Values.application.replicas }}
   selector:

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -16,7 +16,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
-      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- with .Values.deployment.labels }}
   labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -24,6 +25,7 @@ spec:
       {{- end }}
       labels:
         app: {{ .Chart.Name }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
         {{- with .Values.deployment.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -26,7 +26,6 @@ deployment:
   # on the pod, overriding fga.storeId and fga.modelId
   labels:
     openfga-store: "lfx-core"
-    app.kubernetes.io/name: "lfx-v2-fga-sync"
   # podLabels are additional labels to add to the pods
   podLabels: {}
 

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -26,6 +26,7 @@ deployment:
   # on the pod, overriding fga.storeId and fga.modelId
   labels:
     openfga-store: "lfx-core"
+    app.kubernetes.io/name: "lfx-v2-fga-sync"
   # podLabels are additional labels to add to the pods
   podLabels: {}
 


### PR DESCRIPTION
Spotify Backstage can pull kubernetes data from components using deployment annotations. This service is missing the name annotation needed to discover it.