### PR TITLE
[LFXV2-1460] refactor: move GenericFGAMessage types into pkg/types

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -87,6 +87,7 @@
       "filename": "**/*.go",
       "words": [
         "fga",
+        "fgatypes",
         "sync",
         "lfx",
         "ctx",

--- a/handler_generic.go
+++ b/handler_generic.go
@@ -9,49 +9,9 @@ import (
 	"errors"
 
 	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
+	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 	"github.com/openfga/go-sdk/client"
 )
-
-// GenericFGAMessage is the universal message format for all FGA operations.
-// This allows clients to send resource-agnostic messages without needing
-// to know about resource-specific NATS subjects or message formats.
-type GenericFGAMessage struct {
-	ObjectType string                 `json:"object_type"` // e.g., "committee", "project", "meeting"
-	Operation  string                 `json:"operation"`   // e.g., "update_access", "member_put"
-	Data       map[string]interface{} `json:"data"`        // Operation-specific payload
-}
-
-// UnmarshalData unmarshals the data field into a specific type
-func (m *GenericFGAMessage) UnmarshalData(v interface{}) error {
-	bytes, err := json.Marshal(m.Data)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(bytes, v)
-}
-
-// GenericAccessData represents the data field for update_access operations
-type GenericAccessData struct {
-	UID              string              `json:"uid"`
-	Public           bool                `json:"public"`
-	Relations        map[string][]string `json:"relations"`         // relation_name → [usernames]
-	References       map[string][]string `json:"references"`        // relation_name → [object_uids]
-	ExcludeRelations []string            `json:"exclude_relations"` // Optional: relations managed elsewhere
-}
-
-// GenericDeleteData represents the data field for delete_access operations
-type GenericDeleteData struct {
-	UID string `json:"uid"`
-}
-
-// GenericMemberData represents the data field for member_put/member_remove operations.
-// Supports multiple relations for a single user, enabling atomic updates.
-type GenericMemberData struct {
-	UID                   string   `json:"uid"`
-	Username              string   `json:"username"`
-	Relations             []string `json:"relations"`               // Multiple relations supported
-	MutuallyExclusiveWith []string `json:"mutually_exclusive_with"` // Optional: auto-remove these
-}
 
 // genericUpdateAccessHandler handles universal update_access operations.
 // This provides a resource-agnostic way for clients to update access control
@@ -76,7 +36,7 @@ func (h *HandlerService) genericUpdateAccessHandler(message INatsMsg) error {
 	ctx := context.Background()
 
 	// Parse generic message
-	genericMsg := new(GenericFGAMessage)
+	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse generic message")
 		return err
@@ -93,7 +53,7 @@ func (h *HandlerService) genericUpdateAccessHandler(message INatsMsg) error {
 	}
 
 	// Parse data field
-	data := new(GenericAccessData)
+	data := new(fgatypes.GenericAccessData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse access data")
 		return err
@@ -135,7 +95,7 @@ func (h *HandlerService) genericDeleteAccessHandler(message INatsMsg) error {
 	ctx := context.Background()
 
 	// Parse generic message
-	genericMsg := new(GenericFGAMessage)
+	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse generic message")
 		return err
@@ -152,7 +112,7 @@ func (h *HandlerService) genericDeleteAccessHandler(message INatsMsg) error {
 	}
 
 	// Parse data field
-	data := new(GenericDeleteData)
+	data := new(fgatypes.GenericDeleteData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse delete data")
 		return err
@@ -278,9 +238,9 @@ func (h *HandlerService) genericMemberPutHandler(message INatsMsg) error {
 // parseAndValidateMemberPutMessage parses and validates the member_put message
 func (h *HandlerService) parseAndValidateMemberPutMessage(
 	ctx context.Context, message INatsMsg,
-) (*GenericFGAMessage, *GenericMemberData, error) {
+) (*fgatypes.GenericFGAMessage, *fgatypes.GenericMemberData, error) {
 	// Parse generic message
-	genericMsg := new(GenericFGAMessage)
+	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse generic message")
 		return nil, nil, err
@@ -297,7 +257,7 @@ func (h *HandlerService) parseAndValidateMemberPutMessage(
 	}
 
 	// Parse data field
-	data := new(GenericMemberData)
+	data := new(fgatypes.GenericMemberData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse member data")
 		return nil, nil, err
@@ -331,7 +291,7 @@ func (h *HandlerService) parseAndValidateMemberPutMessage(
 func (h *HandlerService) computeMemberPutChanges(
 	ctx context.Context,
 	object, userPrincipal string,
-	data *GenericMemberData,
+	data *fgatypes.GenericMemberData,
 ) ([]client.ClientTupleKey, []client.ClientTupleKeyWithoutCondition, error) {
 	// Build mutually exclusive map for quick lookup
 	mutuallyExclusiveMap := make(map[string]bool)
@@ -468,7 +428,7 @@ func (h *HandlerService) genericMemberRemoveHandler(message INatsMsg) error {
 	ctx := context.Background()
 
 	// Parse generic message
-	genericMsg := new(GenericFGAMessage)
+	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse generic message")
 		return err
@@ -485,7 +445,7 @@ func (h *HandlerService) genericMemberRemoveHandler(message INatsMsg) error {
 	}
 
 	// Parse data field
-	data := new(GenericMemberData)
+	data := new(fgatypes.GenericMemberData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse member data")
 		return err

--- a/main.go
+++ b/main.go
@@ -544,22 +544,22 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 		},
 		// Generic handlers (resource-agnostic)
 		{
-			subject:     "lfx.fga-sync.update_access",
+			subject:     constants.GenericUpdateAccessSubject,
 			handler:     handlerService.genericUpdateAccessHandler,
 			description: "generic update access",
 		},
 		{
-			subject:     "lfx.fga-sync.delete_access",
+			subject:     constants.GenericDeleteAccessSubject,
 			handler:     handlerService.genericDeleteAccessHandler,
 			description: "generic delete access",
 		},
 		{
-			subject:     "lfx.fga-sync.member_put",
+			subject:     constants.GenericMemberPutSubject,
 			handler:     handlerService.genericMemberPutHandler,
 			description: "generic member put",
 		},
 		{
-			subject:     "lfx.fga-sync.member_remove",
+			subject:     constants.GenericMemberRemoveSubject,
 			handler:     handlerService.genericMemberRemoveHandler,
 			description: "generic member remove",
 		},

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -175,3 +175,23 @@ const (
 	// The subject is of the form: lfx.fga-sync.queue
 	FgaSyncQueue = "lfx.fga-sync.queue"
 )
+
+// Generic NATS subjects for resource-agnostic FGA operations.
+// These subjects accept a GenericFGAMessage envelope and route based on object_type.
+const (
+	// GenericUpdateAccessSubject is the subject for generic access control updates.
+	// The subject is of the form: lfx.fga-sync.update_access
+	GenericUpdateAccessSubject = "lfx.fga-sync.update_access"
+
+	// GenericDeleteAccessSubject is the subject for generic access control deletions.
+	// The subject is of the form: lfx.fga-sync.delete_access
+	GenericDeleteAccessSubject = "lfx.fga-sync.delete_access"
+
+	// GenericMemberPutSubject is the subject for generic member add operations.
+	// The subject is of the form: lfx.fga-sync.member_put
+	GenericMemberPutSubject = "lfx.fga-sync.member_put"
+
+	// GenericMemberRemoveSubject is the subject for generic member remove operations.
+	// The subject is of the form: lfx.fga-sync.member_remove
+	GenericMemberRemoveSubject = "lfx.fga-sync.member_remove"
+)

--- a/pkg/types/fga_message.go
+++ b/pkg/types/fga_message.go
@@ -1,0 +1,52 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package types provides shared message type definitions for the fga-sync service.
+// Import this package from any LFX service that publishes FGA sync events so that
+// the message envelope and data payloads stay consistent across the platform.
+package types
+
+import "encoding/json"
+
+// GenericFGAMessage is the universal message format for all FGA operations.
+// This allows clients to send resource-agnostic messages without needing
+// to know about resource-specific NATS subjects or message formats.
+type GenericFGAMessage struct {
+	ObjectType string `json:"object_type"` // e.g., "committee", "project", "meeting"
+	Operation  string `json:"operation"`   // e.g., "update_access", "member_put"
+	Data       any    `json:"data"`        // Operation-specific payload
+}
+
+// UnmarshalData unmarshals the Data field into a specific type.
+// Use this on the consumer side (fga-sync) to decode the operation payload.
+func (m *GenericFGAMessage) UnmarshalData(v any) error {
+	b, err := json.Marshal(m.Data)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
+// GenericAccessData is the Data payload for update_access operations.
+// This is a full sync — any relations not listed (and not excluded) will be removed.
+type GenericAccessData struct {
+	UID              string              `json:"uid"`
+	Public           bool                `json:"public"`
+	Relations        map[string][]string `json:"relations,omitempty"`         // relation_name → [usernames]
+	References       map[string][]string `json:"references,omitempty"`        // relation_name → [object_uids]
+	ExcludeRelations []string            `json:"exclude_relations,omitempty"` // relations managed elsewhere; skipped during sync
+}
+
+// GenericDeleteData is the Data payload for delete_access operations.
+type GenericDeleteData struct {
+	UID string `json:"uid"`
+}
+
+// GenericMemberData is the Data payload for member_put and member_remove operations.
+// Supports multiple relations for a single user, enabling atomic updates.
+type GenericMemberData struct {
+	UID                   string   `json:"uid"`
+	Username              string   `json:"username"`
+	Relations             []string `json:"relations"`                        // relations to add (member_put) or remove (member_remove)
+	MutuallyExclusiveWith []string `json:"mutually_exclusive_with,omitempty"` // on member_put: remove these if present
+}

--- a/pkg/types/fga_message.go
+++ b/pkg/types/fga_message.go
@@ -47,6 +47,6 @@ type GenericDeleteData struct {
 type GenericMemberData struct {
 	UID                   string   `json:"uid"`
 	Username              string   `json:"username"`
-	Relations             []string `json:"relations"`                        // relations to add (member_put) or remove (member_remove)
+	Relations             []string `json:"relations"`                         // relations to add (member_put) or remove (member_remove)
 	MutuallyExclusiveWith []string `json:"mutually_exclusive_with,omitempty"` // on member_put: remove these if present
 }

--- a/pkg/types/fga_message.go
+++ b/pkg/types/fga_message.go
@@ -32,9 +32,9 @@ func (m *GenericFGAMessage) UnmarshalData(v any) error {
 type GenericAccessData struct {
 	UID              string              `json:"uid"`
 	Public           bool                `json:"public"`
-	Relations        map[string][]string `json:"relations,omitempty"`         // relation_name → [usernames]
-	References       map[string][]string `json:"references,omitempty"`        // relation_name → [object_uids]
-	ExcludeRelations []string            `json:"exclude_relations,omitempty"` // relations managed elsewhere; skipped during sync
+	Relations        map[string][]string `json:"relations"`         // relation_name → [usernames]
+	References       map[string][]string `json:"references"`        // relation_name → [object_uids]
+	ExcludeRelations []string            `json:"exclude_relations"` // relations managed elsewhere
 }
 
 // GenericDeleteData is the Data payload for delete_access operations.
@@ -47,6 +47,6 @@ type GenericDeleteData struct {
 type GenericMemberData struct {
 	UID                   string   `json:"uid"`
 	Username              string   `json:"username"`
-	Relations             []string `json:"relations"`                         // relations to add (member_put) or remove (member_remove)
-	MutuallyExclusiveWith []string `json:"mutually_exclusive_with,omitempty"` // on member_put: remove these if present
+	Relations             []string `json:"relations"`               // relations to add or remove
+	MutuallyExclusiveWith []string `json:"mutually_exclusive_with"` // on member_put: remove these
 }

--- a/pkg/types/fga_message_test.go
+++ b/pkg/types/fga_message_test.go
@@ -1,0 +1,92 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGenericFGAMessage_UnmarshalData_Success(t *testing.T) {
+	accessData := GenericAccessData{
+		UID:     "committee-123",
+		Public:  true,
+		Relations: map[string][]string{
+			"member": {"user-alice"},
+		},
+	}
+
+	raw, _ := json.Marshal(accessData)
+	var dataAny any
+	_ = json.Unmarshal(raw, &dataAny)
+
+	msg := GenericFGAMessage{
+		ObjectType: "committee",
+		Operation:  "update_access",
+		Data:       dataAny,
+	}
+
+	var decoded GenericAccessData
+	if err := msg.UnmarshalData(&decoded); err != nil {
+		t.Fatalf("UnmarshalData returned unexpected error: %v", err)
+	}
+	if decoded.UID != accessData.UID {
+		t.Errorf("UID: got %q, want %q", decoded.UID, accessData.UID)
+	}
+	if decoded.Public != accessData.Public {
+		t.Errorf("Public: got %v, want %v", decoded.Public, accessData.Public)
+	}
+	if len(decoded.Relations["member"]) != 1 || decoded.Relations["member"][0] != "user-alice" {
+		t.Errorf("Relations: got %v, want member=[user-alice]", decoded.Relations)
+	}
+}
+
+func TestGenericFGAMessage_UnmarshalData_MemberData(t *testing.T) {
+	memberData := GenericMemberData{
+		UID:      "meeting-456",
+		Username: "user-bob",
+		Relations: []string{"host"},
+		MutuallyExclusiveWith: []string{"participant"},
+	}
+
+	raw, _ := json.Marshal(memberData)
+	var dataAny any
+	_ = json.Unmarshal(raw, &dataAny)
+
+	msg := GenericFGAMessage{
+		ObjectType: "meeting",
+		Operation:  "member_put",
+		Data:       dataAny,
+	}
+
+	var decoded GenericMemberData
+	if err := msg.UnmarshalData(&decoded); err != nil {
+		t.Fatalf("UnmarshalData returned unexpected error: %v", err)
+	}
+	if decoded.Username != memberData.Username {
+		t.Errorf("Username: got %q, want %q", decoded.Username, memberData.Username)
+	}
+	if len(decoded.Relations) != 1 || decoded.Relations[0] != "host" {
+		t.Errorf("Relations: got %v, want [host]", decoded.Relations)
+	}
+	if len(decoded.MutuallyExclusiveWith) != 1 || decoded.MutuallyExclusiveWith[0] != "participant" {
+		t.Errorf("MutuallyExclusiveWith: got %v, want [participant]", decoded.MutuallyExclusiveWith)
+	}
+}
+
+func TestGenericFGAMessage_UnmarshalData_NilData(t *testing.T) {
+	msg := GenericFGAMessage{
+		ObjectType: "committee",
+		Operation:  "update_access",
+		Data:       nil,
+	}
+
+	var decoded GenericAccessData
+	if err := msg.UnmarshalData(&decoded); err != nil {
+		t.Fatalf("UnmarshalData with nil Data returned unexpected error: %v", err)
+	}
+	if decoded.UID != "" {
+		t.Errorf("expected zero-value UID, got %q", decoded.UID)
+	}
+}

--- a/pkg/types/fga_message_test.go
+++ b/pkg/types/fga_message_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestGenericFGAMessage_UnmarshalData_Success(t *testing.T) {
 	accessData := GenericAccessData{
-		UID:     "committee-123",
-		Public:  true,
+		UID:    "committee-123",
+		Public: true,
 		Relations: map[string][]string{
 			"member": {"user-alice"},
 		},
@@ -44,9 +44,9 @@ func TestGenericFGAMessage_UnmarshalData_Success(t *testing.T) {
 
 func TestGenericFGAMessage_UnmarshalData_MemberData(t *testing.T) {
 	memberData := GenericMemberData{
-		UID:      "meeting-456",
-		Username: "user-bob",
-		Relations: []string{"host"},
+		UID:                   "meeting-456",
+		Username:              "user-bob",
+		Relations:             []string{"host"},
 		MutuallyExclusiveWith: []string{"participant"},
 	}
 


### PR DESCRIPTION
## Summary

- Extracts `GenericFGAMessage`, `GenericAccessData`, `GenericDeleteData`, and `GenericMemberData` from `handler_generic.go` into a new shared `pkg/types` package
- Updates `handler_generic.go` to import and use the types directly via `fgatypes.*` — no local aliases, no intermediate types
- Consumer services (mailing-list, committee, meeting, voting, survey) will import `github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types` in follow-up PRs, eliminating their local duplicates

## Ticket

[LFXV2-1460](https://linuxfoundation.atlassian.net/browse/LFXV2-1460)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1460]: https://linuxfoundation.atlassian.net/browse/LFXV2-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ