### PR TITLE
feat: add read_tuples NATS handler (LFXV2-1481)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ FGA Sync is a high-performance Go microservice that synchronizes authorization d
 
 ### Core Components
 
-- **NATS Message Handlers**: Process access checks, project updates, and project deletions
+- **NATS Message Handlers**: Process access checks, read-tuples queries, and resource permission sync (updates, deletes, member operations)
 - **OpenFGA Client**: Manages authorization relationships and batch operations
 - **JetStream Cache**: High-performance KeyValue store for relationship caching
 - **Health Endpoints**: Kubernetes-ready liveness and readiness probes
@@ -20,7 +20,7 @@ FGA Sync is a high-performance Go microservice that synchronizes authorization d
 1. NATS messages arrive on subjects (e.g., `lfx.access_check.request`)
 2. Queue groups ensure load balancing across service instances
 3. Handlers process messages, interact with cache/OpenFGA, and send replies
-4. Cache invalidation occurs on project updates/deletions
+4. Cache invalidation occurs on resource updates/deletions
 
 ### Key Dependencies
 
@@ -102,6 +102,29 @@ Returns all direct OpenFGA tuples for a given user and object type. Paginates in
 ```json
 {"error": "failed to read tuples"}
 ```
+
+### Generic Sync Message Format (`lfx.fga-sync.*`)
+
+New integrations should use the generic subjects. All use the `GenericFGAMessage` envelope:
+
+```json
+{
+  "object_type": "your_resource_type",
+  "operation": "operation_name",
+  "data": { /* operation-specific fields */ }
+}
+```
+
+Subjects: `lfx.fga-sync.update_access`, `lfx.fga-sync.delete_access`, `lfx.fga-sync.member_put`,
+`lfx.fga-sync.member_remove`. See `docs/client-guide.md` for full format details, examples, and best practices.
+
+If a reply subject is provided, sync handlers respond with `OK` after processing, allowing callers to implement
+synchronous acknowledgement.
+
+### Legacy Message Formats
+
+The following resource-specific subjects remain supported for existing publishers but should not be used for new
+integrations. Migrate to the generic `lfx.fga-sync.*` subjects above.
 
 ### Project Update Message (`lfx.update_access.project`)
 
@@ -423,16 +446,15 @@ go test -bench=. ./...
 Each message type has a dedicated handler function:
 
 - `accessCheckHandler()` - Processes authorization queries with caching
-- `projectUpdateHandler()` - Manages project permission synchronization
-- `projectDeleteHandler()` - Handles cleanup of project permissions
-- `committeeUpdateAccessHandler()` - Manages committee permission synchronization
-- `committeeDeleteAllAccessHandler()` - Handles cleanup of committee permissions
-- `committeeMemberPutHandler()` - Adds committee members
-- `committeeMemberRemoveHandler()` - Removes committee members
-- `meetingUpdateAccessHandler()` - Manages meeting permission synchronization
-- `meetingDeleteAllAccessHandler()` - Handles cleanup of meeting permissions
-- `meetingRegistrantPutHandler()` - Adds meeting registrants (participant/host)
-- `meetingRegistrantRemoveHandler()` - Removes meeting registrants
+- `readTuplesHandler()` - Returns all direct OpenFGA tuples for a user + object type
+- `genericUpdateAccessHandler()` - Generic resource permission sync (any object type)
+- `genericDeleteAccessHandler()` - Generic resource permission cleanup
+- `genericMemberPutHandler()` - Generic per-user relation add with multi-relation and mutual exclusion support
+- `genericMemberRemoveHandler()` - Generic per-user relation removal
+
+Legacy resource-specific handlers also exist (e.g. `projectUpdateHandler`, `committeeUpdateAccessHandler`,
+`meetingUpdateAccessHandler`) but new integrations should use the generic handlers above via the
+`lfx.fga-sync.*` subjects.
 
 ### Service Abstraction
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,30 @@ project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456
 
 Multiple relationship checks, one per line. Format: `object#relation@user`
 
+Response is plain text, one line per check, tab-delimited `{request}\t{true|false}`. Order is not guaranteed — cached results are returned first.
+
+### Read Tuples Request (`lfx.access_check.read_tuples`)
+
+Returns all direct OpenFGA tuples for a given user and object type. Paginates internally.
+
+**Request:**
+
+```json
+{"user": "user:auth0|alice", "object_type": "project"}
+```
+
+**Response (success):**
+
+```json
+{"results": ["project:uuid1#writer@user:auth0|alice", "project:uuid2#auditor@user:auth0|alice"]}
+```
+
+**Response (error):**
+
+```json
+{"error": "failed to read tuples"}
+```
+
 ### Project Update Message (`lfx.update_access.project`)
 
 ```json

--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ Returns all direct OpenFGA tuples for a given user and object type. Paginates in
 {"error": "failed to read tuples"}
 ```
 
-### Fire-and-Forget Messages
+### Sync Messages
 
-These subjects are published without expecting a reply. The service processes them asynchronously.
+These subjects handle resource permission synchronization. If a reply subject is provided, the service responds with `OK` after processing, allowing callers to implement synchronous acknowledgement.
 
 #### Resource Update Message
 

--- a/README.md
+++ b/README.md
@@ -171,23 +171,11 @@ Note: if you are developing locally and are writing to the OpenFGA store outside
 (e.g. granting certain access to a test user manually) then you should set `USE_CACHE=false`,
 because otherwise access checks will use the cached access tuples even though they are out of date.
 
-### NATS Subjects
-
-The service subscribes to these NATS subjects:
-
-- `lfx.access_check.request` - Access permission checks
-- `lfx.fga-sync.update_access` - Resource permission sync (create/update)
-- `lfx.fga-sync.delete_access` - Resource permission cleanup (resource deleted)
-- `lfx.fga-sync.member_put` - Per-user relation add/update
-- `lfx.fga-sync.member_remove` - Per-user relation removal
-
-> **Legacy subjects** (`lfx.update_access.<resource_type>`, `lfx.delete_all_access.<resource_type>`) remain supported for existing publishers. New integrations should use the generic `lfx.fga-sync.*` subjects above. See [docs/client-guide.md](docs/client-guide.md) for the current message format.
-
 ## 📚 Documentation
 
 | Document | Description |
 | --- | --- |
-| [docs/client-guide.md](docs/client-guide.md) | How to publish FGA sync messages from your service (message format, subjects, examples) |
+| [docs/client-guide.md](docs/client-guide.md) | NATS API reference — request/reply queries, sync message formats, and integration examples |
 | [docs/fga-catalog.md](docs/fga-catalog.md) | Index of all services publishing FGA sync messages, with links to their FGA contracts |
 
 ## 📊 API Reference
@@ -212,89 +200,25 @@ Returns `200 OK` if the service is ready to handle requests (NATS connected).
 
 ### NATS API
 
-The service exposes request/reply subjects that other services call over NATS.
+The service subscribes to the following NATS subjects. See [docs/client-guide.md](docs/client-guide.md) for message formats, examples, and integration guidance.
+
+#### Request/Reply Subjects
 
 | Subject | Description |
 |---------|-------------|
 | `lfx.access_check.request` | Check one or more authorization relationships |
 | `lfx.access_check.read_tuples` | Return all direct OpenFGA tuples for a user + object type |
 
-#### Access Check
+#### Sync Subjects
 
-**Subject:** `lfx.access_check.request`
+| Subject | Description |
+|---------|-------------|
+| `lfx.fga-sync.update_access` | Create/update access control for a resource |
+| `lfx.fga-sync.delete_access` | Delete all access control for a resource |
+| `lfx.fga-sync.member_put` | Add member(s) with one or more relations |
+| `lfx.fga-sync.member_remove` | Remove member relations |
 
-Checks one or more authorization relationships. Each line is a tuple-string in `object#relation@user` format.
-
-**Request** (plain text, one check per line):
-
-```text
-project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456
-project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456
-```
-
-**Response** (plain text, one line per check, tab-delimited `{request}\t{true|false}`). Order is not guaranteed — cached results are returned first.
-
-```text
-project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456	false
-project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456	true
-```
-
-#### Read Tuples
-
-**Subject:** `lfx.access_check.read_tuples`
-
-Returns all direct OpenFGA tuples for a given user and object type. Paginates internally so the caller receives the full result set.
-
-**Request** (JSON):
-
-```json
-{"user": "user:auth0|alice", "object_type": "project"}
-```
-
-**Response (success)** (JSON):
-
-```json
-{"results": ["project:uuid1#writer@user:auth0|alice", "project:uuid2#auditor@user:auth0|alice"]}
-```
-
-**Response (error)** (JSON):
-
-```json
-{"error": "failed to read tuples"}
-```
-
-### Sync Messages
-
-These subjects handle resource permission synchronization. If a reply subject is provided, the service responds with `OK` after processing, allowing callers to implement synchronous acknowledgement.
-
-#### Resource Update Message
-
-`lfx.update_access.<resource_type>`
-
-Format: this is dependent on the resource since each resource can have its own schema and relations.
-
-Below is an example of the project message schema.
-
-```json
-{
-  "uid": "7cad5a8d-19d0-41a4-81a6-043453daf9ee",
-  "public": true,
-  "parent_uid": "7cad5a8d-19d0-41a4-81a6-043453daf9ef7cad5a8d-19d0-41a4-81a6-043453daf9ee", 
-  "writers": ["user1", "user2"],
-  "auditors": ["auditor1"],
-  "meeting_coordinators": ["coordinator1", "coordinator2"]
-}
-```
-
-#### Resource Delete Message
-
-`lfx.delete_all_access.<resource_type>`
-
-Format: `<resource_uid>` i.e. the resource UID that was deleted so that all access on the resource can be cleaned up.
-
-```text
-7cad5a8d-19d0-41a4-81a6-043453daf9ee
-```
+> **Legacy subjects** (`lfx.update_access.<resource_type>`, `lfx.delete_all_access.<resource_type>`, etc.) remain supported for existing publishers. New integrations should use the generic `lfx.fga-sync.*` subjects above.
 
 ## 🧪 Development
 

--- a/README.md
+++ b/README.md
@@ -210,17 +210,62 @@ GET /readyz
 
 Returns `200 OK` if the service is ready to handle requests (NATS connected).
 
-### Message Formats
+### NATS API
 
-#### Access Check Request
+The service exposes request/reply subjects that other services call over NATS.
 
-`lfx.access_check.request`
+| Subject | Description |
+|---------|-------------|
+| `lfx.access_check.request` | Check one or more authorization relationships |
+| `lfx.access_check.read_tuples` | Return all direct OpenFGA tuples for a user + object type |
 
-Format: `object#relation@user`
+#### Access Check
+
+**Subject:** `lfx.access_check.request`
+
+Checks one or more authorization relationships. Each line is a tuple-string in `object#relation@user` format.
+
+**Request** (plain text, one check per line):
 
 ```text
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456
 project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456
 ```
+
+**Response** (plain text, one line per check, tab-delimited `{request}\t{true|false}`). Order is not guaranteed — cached results are returned first.
+
+```text
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456	false
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456	true
+```
+
+#### Read Tuples
+
+**Subject:** `lfx.access_check.read_tuples`
+
+Returns all direct OpenFGA tuples for a given user and object type. Paginates internally so the caller receives the full result set.
+
+**Request** (JSON):
+
+```json
+{"user": "user:auth0|alice", "object_type": "project"}
+```
+
+**Response (success)** (JSON):
+
+```json
+{"results": ["project:uuid1#writer@user:auth0|alice", "project:uuid2#auditor@user:auth0|alice"]}
+```
+
+**Response (error)** (JSON):
+
+```json
+{"error": "failed to read tuples"}
+```
+
+### Fire-and-Forget Messages
+
+These subjects are published without expecting a reply. The service processes them asynchronously.
 
 #### Resource Update Message
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -1,10 +1,66 @@
-# FGA Sync Client Guide - Generic Handlers
+# FGA Sync Client Guide
 
-This guide explains how to use the **generic, resource-agnostic** FGA Sync handlers to manage fine-grained authorization for your resources.
+This guide explains how to use the FGA Sync service's NATS API to manage fine-grained authorization for your resources.
 
-## Overview
+## Request/Reply API
 
-The FGA Sync service provides four universal NATS subjects that work with **any resource type** (projects, committees, meetings, etc.) without requiring resource-specific handlers.
+These subjects use NATS request/reply for synchronous queries.
+
+### Access Check
+
+**Subject:** `lfx.access_check.request`
+
+Checks one or more authorization relationships. Each line is a tuple-string in `object#relation@user` format.
+
+**Request** (plain text, one check per line):
+
+```text
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456
+```
+
+**Response** (plain text, one line per check, tab-delimited `{request}\t{true|false}`). Order is not guaranteed — cached results are returned first.
+
+```text
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456	false
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456	true
+```
+
+### Read Tuples
+
+**Subject:** `lfx.access_check.read_tuples`
+
+Returns all direct OpenFGA tuples for a given user and object type. Paginates internally so the caller receives the full result set.
+
+**Request** (JSON):
+
+```json
+{"user": "user:auth0|alice", "object_type": "project"}
+```
+
+**Response (success)** (JSON):
+
+```json
+{"results": ["project:uuid1#writer@user:auth0|alice", "project:uuid2#auditor@user:auth0|alice"]}
+```
+
+If no tuples are found:
+
+```json
+{"results": []}
+```
+
+**Response (error)** (JSON):
+
+```json
+{"error": "failed to read tuples"}
+```
+
+---
+
+## Sync API — Generic Handlers
+
+The FGA Sync service provides four universal NATS subjects that work with **any resource type** (projects, committees, meetings, etc.) without requiring resource-specific handlers. If a reply subject is provided, the service responds with `OK` after processing, allowing callers to implement synchronous acknowledgement.
 
 ### Benefits of Generic Handlers
 

--- a/fga.go
+++ b/fga.go
@@ -133,6 +133,31 @@ func (s FgaService) ReadObjectTuples(ctx context.Context, object string) ([]open
 	return tuples, nil
 }
 
+// ReadUserTuples fetches all direct relationships for a given user across all
+// objects of the specified type. It paginates internally via ContinuationToken.
+func (s FgaService) ReadUserTuples(ctx context.Context, user, objectType string) ([]openfga.Tuple, error) {
+	objectTypeColon := objectType + ":"
+	req := ClientReadRequest{
+		User:   openfga.PtrString(user),
+		Object: openfga.PtrString(objectTypeColon),
+	}
+	options := ClientReadOptions{}
+	var tuples []openfga.Tuple
+	for {
+		resp, err := s.client.Read(ctx, req, options)
+		if err != nil {
+			return nil, err
+		}
+		tuples = append(tuples, resp.Tuples...)
+		if resp.ContinuationToken == "" {
+			break
+		}
+		options.ContinuationToken = openfga.PtrString(resp.ContinuationToken)
+	}
+
+	return tuples, nil
+}
+
 // ListObjectsByUserAndRelation uses the List Objects API to find all objects of a specific type
 // that have a given relation to a user. This is useful for finding all artifacts that relate to a past meeting.
 func (s FgaService) ListObjectsByUserAndRelation(

--- a/handler_read_tuples.go
+++ b/handler_read_tuples.go
@@ -32,22 +32,32 @@ func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
 	}
 
 	if req.User == "" || req.ObjectType == "" {
-		logger.WarnContext(ctx, "read tuples request missing required fields", "user", req.User, "object_type", req.ObjectType)
+		logger.With(
+			"user", req.User,
+			"object_type", req.ObjectType,
+		).WarnContext(ctx, "read tuples request missing required fields")
 		return h.respondReadTuplesError(ctx, message, "user and object_type are required")
 	}
 
 	// Validate that object_type is a clean type name (no colons).
 	if strings.Contains(req.ObjectType, ":") {
-		logger.WarnContext(ctx, "read tuples request contains invalid object_type", "object_type", req.ObjectType)
+		logger.With("object_type", req.ObjectType).WarnContext(ctx, "read tuples request contains invalid object_type")
 		return h.respondReadTuplesError(ctx, message, "object_type must not contain ':'")
 	}
 
-	logger.With("user", req.User, "object_type", req.ObjectType).InfoContext(ctx, "handling read tuples request")
+	logger.With(
+		"user", req.User,
+		"object_type", req.ObjectType,
+	).InfoContext(ctx, "handling read tuples request")
 
 	// Query OpenFGA for all direct tuples matching the user + object type.
 	tuples, err := h.fgaService.ReadUserTuples(ctx, req.User, req.ObjectType)
 	if err != nil {
-		logger.With(errKey, err, "user", req.User, "object_type", req.ObjectType).ErrorContext(ctx, "failed to read user tuples")
+		logger.With(
+			errKey, err,
+			"user", req.User,
+			"object_type", req.ObjectType,
+		).ErrorContext(ctx, "failed to read user tuples")
 		return h.respondReadTuplesError(ctx, message, "failed to read tuples")
 	}
 
@@ -72,7 +82,11 @@ func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
 			logger.With(errKey, errRespond).WarnContext(ctx, "failed to send read tuples reply")
 			return errRespond
 		}
-		logger.With("user", req.User, "object_type", req.ObjectType, "count", len(results)).InfoContext(ctx, "sent read tuples response")
+		logger.With(
+			"user", req.User,
+			"object_type", req.ObjectType,
+			"count", len(results),
+		).InfoContext(ctx, "sent read tuples response")
 	}
 
 	return nil

--- a/handler_read_tuples.go
+++ b/handler_read_tuples.go
@@ -80,18 +80,17 @@ func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
 
 // respondReadTuplesError sends a JSON error response over NATS and returns a
 // formatted error so the subscription loop can log it consistently with other
-// handlers.
-func (h *HandlerService) respondReadTuplesError(ctx context.Context, message INatsMsg, errMsg string) error {
+// handlers. This helper does not log — callers are responsible for logging
+// before calling it.
+func (h *HandlerService) respondReadTuplesError(_ context.Context, message INatsMsg, errMsg string) error {
 	if message.Reply() != "" {
 		resp := types.ReadTuplesResponse{Error: errMsg}
 		data, err := json.Marshal(resp)
 		if err != nil {
-			logger.With(errKey, err).ErrorContext(ctx, "failed to marshal error response")
-			return err
+			return fmt.Errorf("read tuples: %s (marshal error response: %w)", errMsg, err)
 		}
 		if errRespond := message.Respond(data); errRespond != nil {
-			logger.With(errKey, errRespond).WarnContext(ctx, "failed to send error reply")
-			return errRespond
+			return fmt.Errorf("read tuples: %s (send error reply: %w)", errMsg, errRespond)
 		}
 	}
 	return fmt.Errorf("read tuples: %s", errMsg)

--- a/handler_read_tuples.go
+++ b/handler_read_tuples.go
@@ -8,26 +8,38 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 )
+
+// readTuplesTimeout is the maximum time allowed for the OpenFGA read call.
+const readTuplesTimeout = 10 * time.Second
 
 // readTuplesHandler handles requests to read a user's direct OpenFGA tuples for
 // a given object type. It responds with a JSON-encoded ReadTuplesResponse
 // containing tuple-strings in object#relation@user format.
 func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), readTuplesTimeout)
+	defer cancel()
 
 	// Unmarshal the JSON request payload.
 	var req types.ReadTuplesRequest
 	if err := json.Unmarshal(message.Data(), &req); err != nil {
 		logger.With(errKey, err).WarnContext(ctx, "failed to unmarshal read tuples request")
-		return h.respondReadTuplesError(message, fmt.Sprintf("failed to unmarshal request: %s", err))
+		return h.respondReadTuplesError(ctx, message, "invalid request payload")
 	}
 
 	if req.User == "" || req.ObjectType == "" {
 		logger.WarnContext(ctx, "read tuples request missing required fields", "user", req.User, "object_type", req.ObjectType)
-		return h.respondReadTuplesError(message, "user and object_type are required")
+		return h.respondReadTuplesError(ctx, message, "user and object_type are required")
+	}
+
+	// Validate that object_type is a clean type name (no colons).
+	if strings.Contains(req.ObjectType, ":") {
+		logger.WarnContext(ctx, "read tuples request contains invalid object_type", "object_type", req.ObjectType)
+		return h.respondReadTuplesError(ctx, message, "object_type must not contain ':'")
 	}
 
 	logger.With("user", req.User, "object_type", req.ObjectType).InfoContext(ctx, "handling read tuples request")
@@ -36,7 +48,7 @@ func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
 	tuples, err := h.fgaService.ReadUserTuples(ctx, req.User, req.ObjectType)
 	if err != nil {
 		logger.With(errKey, err, "user", req.User, "object_type", req.ObjectType).ErrorContext(ctx, "failed to read user tuples")
-		return h.respondReadTuplesError(message, fmt.Sprintf("failed to read tuples: %s", err))
+		return h.respondReadTuplesError(ctx, message, "failed to read tuples")
 	}
 
 	// Convert []openfga.Tuple to tuple-strings: object#relation@user.
@@ -52,7 +64,7 @@ func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
 	data, err := json.Marshal(resp)
 	if err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to marshal read tuples response")
-		return h.respondReadTuplesError(message, fmt.Sprintf("failed to marshal response: %s", err))
+		return h.respondReadTuplesError(ctx, message, "failed to marshal response")
 	}
 
 	if message.Reply() != "" {
@@ -66,21 +78,21 @@ func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
 	return nil
 }
 
-// respondReadTuplesError sends a JSON error response and returns nil so the
-// subscription loop does not log a redundant error.
-func (h *HandlerService) respondReadTuplesError(message INatsMsg, errMsg string) error {
-	if message.Reply() == "" {
-		return nil
+// respondReadTuplesError sends a JSON error response over NATS and returns a
+// formatted error so the subscription loop can log it consistently with other
+// handlers.
+func (h *HandlerService) respondReadTuplesError(ctx context.Context, message INatsMsg, errMsg string) error {
+	if message.Reply() != "" {
+		resp := types.ReadTuplesResponse{Error: errMsg}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			logger.With(errKey, err).ErrorContext(ctx, "failed to marshal error response")
+			return err
+		}
+		if errRespond := message.Respond(data); errRespond != nil {
+			logger.With(errKey, errRespond).WarnContext(ctx, "failed to send error reply")
+			return errRespond
+		}
 	}
-	resp := types.ReadTuplesResponse{Error: errMsg}
-	data, err := json.Marshal(resp)
-	if err != nil {
-		logger.With(errKey, err).ErrorContext(context.Background(), "failed to marshal error response")
-		return err
-	}
-	if errRespond := message.Respond(data); errRespond != nil {
-		logger.With(errKey, errRespond).WarnContext(context.Background(), "failed to send error reply")
-		return errRespond
-	}
-	return nil
+	return fmt.Errorf("read tuples: %s", errMsg)
 }

--- a/handler_read_tuples.go
+++ b/handler_read_tuples.go
@@ -1,0 +1,86 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// The fga-sync service.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
+)
+
+// readTuplesHandler handles requests to read a user's direct OpenFGA tuples for
+// a given object type. It responds with a JSON-encoded ReadTuplesResponse
+// containing tuple-strings in object#relation@user format.
+func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
+	ctx := context.Background()
+
+	// Unmarshal the JSON request payload.
+	var req types.ReadTuplesRequest
+	if err := json.Unmarshal(message.Data(), &req); err != nil {
+		logger.With(errKey, err).WarnContext(ctx, "failed to unmarshal read tuples request")
+		return h.respondReadTuplesError(message, fmt.Sprintf("failed to unmarshal request: %s", err))
+	}
+
+	if req.User == "" || req.ObjectType == "" {
+		logger.WarnContext(ctx, "read tuples request missing required fields", "user", req.User, "object_type", req.ObjectType)
+		return h.respondReadTuplesError(message, "user and object_type are required")
+	}
+
+	logger.With("user", req.User, "object_type", req.ObjectType).InfoContext(ctx, "handling read tuples request")
+
+	// Query OpenFGA for all direct tuples matching the user + object type.
+	tuples, err := h.fgaService.ReadUserTuples(ctx, req.User, req.ObjectType)
+	if err != nil {
+		logger.With(errKey, err, "user", req.User, "object_type", req.ObjectType).ErrorContext(ctx, "failed to read user tuples")
+		return h.respondReadTuplesError(message, fmt.Sprintf("failed to read tuples: %s", err))
+	}
+
+	// Convert []openfga.Tuple to tuple-strings: object#relation@user.
+	results := make([]string, 0, len(tuples))
+	for _, t := range tuples {
+		if t.Key.Object == "" || t.Key.Relation == "" || t.Key.User == "" {
+			continue
+		}
+		results = append(results, fmt.Sprintf("%s#%s@%s", t.Key.Object, t.Key.Relation, t.Key.User))
+	}
+
+	resp := types.ReadTuplesResponse{Results: results}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(ctx, "failed to marshal read tuples response")
+		return h.respondReadTuplesError(message, fmt.Sprintf("failed to marshal response: %s", err))
+	}
+
+	if message.Reply() != "" {
+		if errRespond := message.Respond(data); errRespond != nil {
+			logger.With(errKey, errRespond).WarnContext(ctx, "failed to send read tuples reply")
+			return errRespond
+		}
+		logger.With("user", req.User, "object_type", req.ObjectType, "count", len(results)).InfoContext(ctx, "sent read tuples response")
+	}
+
+	return nil
+}
+
+// respondReadTuplesError sends a JSON error response and returns nil so the
+// subscription loop does not log a redundant error.
+func (h *HandlerService) respondReadTuplesError(message INatsMsg, errMsg string) error {
+	if message.Reply() == "" {
+		return nil
+	}
+	resp := types.ReadTuplesResponse{Error: errMsg}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(context.Background(), "failed to marshal error response")
+		return err
+	}
+	if errRespond := message.Respond(data); errRespond != nil {
+		logger.With(errKey, errRespond).WarnContext(context.Background(), "failed to send error reply")
+		return errRespond
+	}
+	return nil
+}

--- a/handler_read_tuples_test.go
+++ b/handler_read_tuples_test.go
@@ -171,7 +171,7 @@ func TestReadTuplesHandler(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:         "empty results returned as empty slice",
+			name:         "empty results returned as empty array",
 			messageData:  []byte(`{"user":"user:auth0|nobody","object_type":"project"}`),
 			replySubject: "reply.456",
 			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
@@ -184,13 +184,14 @@ func TestReadTuplesHandler(t *testing.T) {
 					if err := json.Unmarshal(data, &resp); err != nil {
 						return false
 					}
-					return len(resp.Results) == 0 && resp.Error == ""
+					// Results should be present as empty array, not nil.
+					return resp.Results != nil && len(resp.Results) == 0 && resp.Error == ""
 				})).Return(nil).Once()
 			},
 			expectError: false,
 		},
 		{
-			name:         "OpenFGA error returns JSON error response",
+			name:         "OpenFGA error returns generic JSON error",
 			messageData:  []byte(`{"user":"user:auth0|err","object_type":"project"}`),
 			replySubject: "reply.err",
 			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
@@ -202,10 +203,11 @@ func TestReadTuplesHandler(t *testing.T) {
 					if err := json.Unmarshal(data, &resp); err != nil {
 						return false
 					}
-					return resp.Error != "" && resp.Results == nil
+					// Error message should not contain internal details.
+					return resp.Error == "failed to read tuples"
 				})).Return(nil).Once()
 			},
-			expectError: false, // handler sends JSON error, does not return Go error
+			expectError: true, // Handler now returns error for subscription-layer logging.
 		},
 		{
 			name:         "invalid JSON payload returns error response",
@@ -217,10 +219,11 @@ func TestReadTuplesHandler(t *testing.T) {
 					if err := json.Unmarshal(data, &resp); err != nil {
 						return false
 					}
-					return resp.Error != ""
+					// Should not leak unmarshal error details.
+					return resp.Error == "invalid request payload"
 				})).Return(nil).Once()
 			},
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name:         "missing user field returns error response",
@@ -235,7 +238,22 @@ func TestReadTuplesHandler(t *testing.T) {
 					return resp.Error != ""
 				})).Return(nil).Once()
 			},
-			expectError: false,
+			expectError: true,
+		},
+		{
+			name:         "object_type with colon is rejected",
+			messageData:  []byte(`{"user":"user:auth0|alice","object_type":"project:"}`),
+			replySubject: "reply.colon",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ReadTuplesResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error == "object_type must not contain ':'"
+				})).Return(nil).Once()
+			},
+			expectError: true,
 		},
 		{
 			name:         "no reply subject — no Respond call",

--- a/handler_read_tuples_test.go
+++ b/handler_read_tuples_test.go
@@ -228,7 +228,7 @@ func TestReadTuplesHandler(t *testing.T) {
 		{
 			name:         "missing user field returns error response",
 			messageData:  []byte(`{"object_type":"project"}`),
-			replySubject: "reply.nouser",
+			replySubject: "reply.no-user",
 			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
 				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
 					var resp types.ReadTuplesResponse

--- a/handler_read_tuples_test.go
+++ b/handler_read_tuples_test.go
@@ -1,0 +1,275 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	openfga "github.com/openfga/go-sdk"
+	"github.com/openfga/go-sdk/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
+)
+
+// TestReadUserTuples tests the ReadUserTuples method of FgaService.
+func TestReadUserTuples(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           string
+		objectType     string
+		mockSetup      func(*MockFgaClient)
+		expectedTuples []openfga.Tuple
+		expectError    bool
+		description    string
+	}{
+		{
+			name:       "single page of tuples",
+			user:       "user:auth0|alice",
+			objectType: "project",
+			mockSetup: func(m *MockFgaClient) {
+				m.On("Read", mock.Anything, mock.MatchedBy(func(req client.ClientReadRequest) bool {
+					return req.User != nil && *req.User == "user:auth0|alice" &&
+						req.Object != nil && *req.Object == "project:"
+				}), mock.Anything).Return(&client.ClientReadResponse{
+					Tuples: []openfga.Tuple{
+						{Key: openfga.TupleKey{Object: "project:uuid1", Relation: "writer", User: "user:auth0|alice"}},
+						{Key: openfga.TupleKey{Object: "project:uuid2", Relation: "auditor", User: "user:auth0|alice"}},
+					},
+					ContinuationToken: "",
+				}, nil).Once()
+			},
+			expectedTuples: []openfga.Tuple{
+				{Key: openfga.TupleKey{Object: "project:uuid1", Relation: "writer", User: "user:auth0|alice"}},
+				{Key: openfga.TupleKey{Object: "project:uuid2", Relation: "auditor", User: "user:auth0|alice"}},
+			},
+			expectError: false,
+			description: "should return all tuples from single page",
+		},
+		{
+			name:       "multiple pages with pagination",
+			user:       "user:auth0|bob",
+			objectType: "committee",
+			mockSetup: func(m *MockFgaClient) {
+				// First page.
+				m.On("Read", mock.Anything, mock.MatchedBy(func(req client.ClientReadRequest) bool {
+					return req.User != nil && *req.User == "user:auth0|bob" &&
+						req.Object != nil && *req.Object == "committee:"
+				}), mock.MatchedBy(func(opts client.ClientReadOptions) bool {
+					return opts.ContinuationToken == nil
+				})).Return(&client.ClientReadResponse{
+					Tuples: []openfga.Tuple{
+						{Key: openfga.TupleKey{Object: "committee:c1", Relation: "member", User: "user:auth0|bob"}},
+					},
+					ContinuationToken: "page-2",
+				}, nil).Once()
+				// Second page.
+				m.On("Read", mock.Anything, mock.MatchedBy(func(req client.ClientReadRequest) bool {
+					return req.User != nil && *req.User == "user:auth0|bob" &&
+						req.Object != nil && *req.Object == "committee:"
+				}), mock.MatchedBy(func(opts client.ClientReadOptions) bool {
+					return opts.ContinuationToken != nil && *opts.ContinuationToken == "page-2"
+				})).Return(&client.ClientReadResponse{
+					Tuples: []openfga.Tuple{
+						{Key: openfga.TupleKey{Object: "committee:c2", Relation: "member", User: "user:auth0|bob"}},
+					},
+					ContinuationToken: "",
+				}, nil).Once()
+			},
+			expectedTuples: []openfga.Tuple{
+				{Key: openfga.TupleKey{Object: "committee:c1", Relation: "member", User: "user:auth0|bob"}},
+				{Key: openfga.TupleKey{Object: "committee:c2", Relation: "member", User: "user:auth0|bob"}},
+			},
+			expectError: false,
+			description: "should aggregate tuples across pages",
+		},
+		{
+			name:       "empty result",
+			user:       "user:auth0|nobody",
+			objectType: "project",
+			mockSetup: func(m *MockFgaClient) {
+				m.On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{
+					Tuples:            []openfga.Tuple{},
+					ContinuationToken: "",
+				}, nil).Once()
+			},
+			expectedTuples: []openfga.Tuple{},
+			expectError:    false,
+			description:    "should handle empty result without error",
+		},
+		{
+			name:       "OpenFGA error",
+			user:       "user:auth0|err",
+			objectType: "project",
+			mockSetup: func(m *MockFgaClient) {
+				m.On("Read", mock.Anything, mock.Anything, mock.Anything).Return(
+					(*client.ClientReadResponse)(nil), errors.New("openfga unavailable"),
+				).Once()
+			},
+			expectedTuples: nil,
+			expectError:    true,
+			description:    "should propagate OpenFGA errors",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockFgaClient{}
+			tt.mockSetup(mockClient)
+			svc := FgaService{client: mockClient, cacheBucket: NewMockKeyValue()}
+
+			tuples, err := svc.ReadUserTuples(t.Context(), tt.user, tt.objectType)
+
+			if tt.expectError {
+				assert.Error(t, err, tt.description)
+			} else {
+				assert.NoError(t, err, tt.description)
+				assert.Equal(t, len(tt.expectedTuples), len(tuples), tt.description)
+			}
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+// TestReadTuplesHandler tests the readTuplesHandler function.
+func TestReadTuplesHandler(t *testing.T) {
+	tests := []struct {
+		name         string
+		messageData  []byte
+		replySubject string
+		mockSetup    func(*MockFgaClient, *MockNatsMsg)
+		expectError  bool
+	}{
+		{
+			name:         "success returns tuple-strings",
+			messageData:  []byte(`{"user":"user:auth0|alice","object_type":"project"}`),
+			replySubject: "reply.123",
+			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
+				m.On("Read", mock.Anything, mock.MatchedBy(func(req client.ClientReadRequest) bool {
+					return req.User != nil && *req.User == "user:auth0|alice" &&
+						req.Object != nil && *req.Object == "project:"
+				}), mock.Anything).Return(&client.ClientReadResponse{
+					Tuples: []openfga.Tuple{
+						{Key: openfga.TupleKey{Object: "project:uuid1", Relation: "writer", User: "user:auth0|alice"}},
+					},
+					ContinuationToken: "",
+				}, nil).Once()
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ReadTuplesResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return len(resp.Results) == 1 &&
+						resp.Results[0] == "project:uuid1#writer@user:auth0|alice" &&
+						resp.Error == ""
+				})).Return(nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:         "empty results returned as empty slice",
+			messageData:  []byte(`{"user":"user:auth0|nobody","object_type":"project"}`),
+			replySubject: "reply.456",
+			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
+				m.On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{
+					Tuples:            []openfga.Tuple{},
+					ContinuationToken: "",
+				}, nil).Once()
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ReadTuplesResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return len(resp.Results) == 0 && resp.Error == ""
+				})).Return(nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:         "OpenFGA error returns JSON error response",
+			messageData:  []byte(`{"user":"user:auth0|err","object_type":"project"}`),
+			replySubject: "reply.err",
+			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
+				m.On("Read", mock.Anything, mock.Anything, mock.Anything).Return(
+					(*client.ClientReadResponse)(nil), errors.New("store unavailable"),
+				).Once()
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ReadTuplesResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error != "" && resp.Results == nil
+				})).Return(nil).Once()
+			},
+			expectError: false, // handler sends JSON error, does not return Go error
+		},
+		{
+			name:         "invalid JSON payload returns error response",
+			messageData:  []byte(`not-json`),
+			replySubject: "reply.bad",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ReadTuplesResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error != ""
+				})).Return(nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:         "missing user field returns error response",
+			messageData:  []byte(`{"object_type":"project"}`),
+			replySubject: "reply.nouser",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ReadTuplesResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error != ""
+				})).Return(nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:         "no reply subject — no Respond call",
+			messageData:  []byte(`{"user":"user:auth0|alice","object_type":"project"}`),
+			replySubject: "",
+			mockSetup: func(m *MockFgaClient, _ *MockNatsMsg) {
+				m.On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{
+					Tuples:            []openfga.Tuple{},
+					ContinuationToken: "",
+				}, nil).Once()
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := setupService()
+			msg := CreateMockNatsMsg(tt.messageData)
+			msg.reply = tt.replySubject
+
+			tt.mockSetup(service.fgaService.client.(*MockFgaClient), msg)
+
+			assert.NotPanics(t, func() {
+				err := service.readTuplesHandler(msg)
+				if tt.expectError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+
+			msg.AssertExpectations(t)
+			service.fgaService.client.(*MockFgaClient).AssertExpectations(t)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -353,6 +353,11 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 			description: "access check",
 		},
 		{
+			subject:     constants.ReadTuplesSubject,
+			handler:     handlerService.readTuplesHandler,
+			description: "read tuples",
+		},
+		{
 			subject:     constants.ProjectUpdateAccessSubject,
 			handler:     handlerService.projectUpdateAccessHandler,
 			description: "project update access",

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -15,6 +15,10 @@ const (
 	// The subject is of the form: lfx.access_check.request
 	AccessCheckSubject = "lfx.access_check.request"
 
+	// ReadTuplesSubject is the subject for reading a user's direct tuples by object type.
+	// The subject is of the form: lfx.access_check.read_tuples
+	ReadTuplesSubject = "lfx.access_check.read_tuples"
+
 	// ProjectUpdateAccessSubject is the subject for the project access control updates.
 	// The subject is of the form: lfx.update_access.project
 	ProjectUpdateAccessSubject = "lfx.update_access.project"

--- a/pkg/types/read_tuples.go
+++ b/pkg/types/read_tuples.go
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package types contains shared message types for the fga-sync service.
+package types
+
+// ReadTuplesRequest is the JSON payload received over NATS for the
+// lfx.access_check.read_tuples subject.
+type ReadTuplesRequest struct {
+	User       string `json:"user"`
+	ObjectType string `json:"object_type"`
+}
+
+// ReadTuplesResponse is the JSON response sent back over NATS for the
+// lfx.access_check.read_tuples subject. Results are tuple-strings in
+// the canonical object#relation@user format. Error is set on failure.
+type ReadTuplesResponse struct {
+	Results []string `json:"results,omitempty"`
+	Error   string   `json:"error,omitempty"`
+}

--- a/pkg/types/read_tuples.go
+++ b/pkg/types/read_tuples.go
@@ -15,6 +15,6 @@ type ReadTuplesRequest struct {
 // lfx.access_check.read_tuples subject. Results are tuple-strings in
 // the canonical object#relation@user format. Error is set on failure.
 type ReadTuplesResponse struct {
-	Results []string `json:"results,omitempty"`
+	Results []string `json:"results"`
 	Error   string   `json:"error,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds Phase 1 of LFXV2-1481: a new NATS request/reply handler on subject `lfx.access_check.read_tuples` that returns all OpenFGA tuples for a given user and object type. This is consumed by `lfx-v2-access-check`'s `GET /my-grants` endpoint.

## Changes

- `pkg/constants/nats.go` — added `ReadTuplesSubject = "lfx.access_check.read_tuples"`
- `pkg/types/read_tuples.go` — new `ReadTuplesRequest` / `ReadTuplesResponse` types
- `fga.go` — added `ReadUserTuples(ctx, user, objectType)` with full pagination (follows existing `ReadObjectTuples` pattern)
- `handler_read_tuples.go` — new `readTuplesHandler` with `respondReadTuplesError` helper
- `main.go` — registered handler in `createQueueSubscriptions()`
- `handler_read_tuples_test.go` — unit tests for handler and service method

## NATS Protocol

**Request** (`lfx.access_check.read_tuples`):
```json
{"user": "user:<principal>", "object_type": "<type>"}
```

**Response (success)**:
```json
{"results": ["object#relation@user", ...]}
```

**Response (error)**:
```json
{"error": "..."}
```

## Testing

All existing tests continue to pass (`go test ./...`). New tests cover:
- Happy path with multiple tuples
- Empty result set
- Missing/invalid request fields
- OpenFGA error propagation

## Jira

[LFXV2-1481](https://linuxfoundation.atlassian.net/browse/LFXV2-1481)

---
🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[LFXV2-1481]: https://linuxfoundation.atlassian.net/browse/LFXV2-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ