### PR TITLE
Annotate kv buckets for backstage discovery

### DIFF
--- a/charts/lfx-v2-fga-sync/templates/nats-kv-bucket.yaml
+++ b/charts/lfx-v2-fga-sync/templates/nats-kv-bucket.yaml
@@ -11,6 +11,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.cacheFgaKvBucket.name }}
   history: {{ .Values.nats.cacheFgaKvBucket.history }}


### PR DESCRIPTION
For the `keyvalues` CRD to populate in backstage, the kv bucket must be labeled. We'll use this data to check replica counts