### PR TITLE
Skip invalid tuples and retry batch writes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -116,7 +116,8 @@
         "tracecontext",
         "traceparent",
         "tracestate",
-        "INTERNALERRORCODE"
+        "INTERNALERRORCODE",
+        "noctx"
       ]
     },
     {

--- a/fga.go
+++ b/fga.go
@@ -523,7 +523,10 @@ func removeInvalidWriteTuple(writes []ClientTupleKey, tupleStr string) ([]Client
 
 // removeInvalidDeleteTuple returns a new slice with the first delete tuple matching
 // tupleStr removed. Returns the original slice and false if no match is found.
-func removeInvalidDeleteTuple(deletes []ClientTupleKeyWithoutCondition, tupleStr string) ([]ClientTupleKeyWithoutCondition, bool) {
+func removeInvalidDeleteTuple(
+	deletes []ClientTupleKeyWithoutCondition,
+	tupleStr string,
+) ([]ClientTupleKeyWithoutCondition, bool) {
 	for i, t := range deletes {
 		if t.Object+"#"+t.Relation+"@"+t.User == tupleStr {
 			result := make([]ClientTupleKeyWithoutCondition, 0, len(deletes)-1)

--- a/fga.go
+++ b/fga.go
@@ -495,18 +495,16 @@ func extractInvalidTuple(err error) (string, bool) {
 	if !errors.As(err, &validationErr) {
 		return "", false
 	}
-	msg := validationErr.Error()
 	const prefix = "Invalid tuple '"
-	start := strings.Index(msg, prefix)
-	if start == -1 {
+	_, afterPrefix, found := bytes.Cut([]byte(validationErr.Error()), []byte(prefix))
+	if !found {
 		return "", false
 	}
-	start += len(prefix)
-	end := strings.Index(msg[start:], "'")
-	if end == -1 {
+	tuple, _, found := bytes.Cut(afterPrefix, []byte("'"))
+	if !found {
 		return "", false
 	}
-	return msg[start : start+end], true
+	return string(tuple), true
 }
 
 // removeInvalidWriteTuple returns a new slice with the first write tuple matching

--- a/fga.go
+++ b/fga.go
@@ -426,20 +426,49 @@ func (s FgaService) WriteAndDeleteTuples(
 }
 
 // writeAndDeleteTuplesBatch performs a single write/delete operation to OpenFGA.
+// If OpenFGA returns a validation_error for an invalid tuple, that tuple is
+// removed and the batch is retried with the remaining tuples.
 // This is an internal helper function that should not be called directly.
 func (s FgaService) writeAndDeleteTuplesBatch(
 	ctx context.Context,
 	writes []ClientTupleKey,
 	deletes []ClientTupleKeyWithoutCondition,
 ) error {
-	req := ClientWriteRequest{
-		Writes:  writes,
-		Deletes: deletes,
-	}
+	for {
+		req := ClientWriteRequest{
+			Writes:  writes,
+			Deletes: deletes,
+		}
 
-	_, err := s.client.Write(ctx, req)
-	if err != nil {
-		return err
+		_, err := s.client.Write(ctx, req)
+		if err != nil {
+			tupleStr, ok := extractInvalidTuple(err)
+			if !ok {
+				return err
+			}
+
+			removed := false
+			writes, removed = removeInvalidWriteTuple(writes, tupleStr)
+			if !removed {
+				deletes, removed = removeInvalidDeleteTuple(deletes, tupleStr)
+			}
+			if !removed {
+				return err
+			}
+
+			logger.With(
+				"skipped_tuple", tupleStr,
+				"remaining_writes", len(writes),
+				"remaining_deletes", len(deletes),
+			).WarnContext(ctx, "skipping invalid tuple and retrying batch write")
+
+			if len(writes) == 0 && len(deletes) == 0 {
+				return nil
+			}
+			continue
+		}
+
+		break
 	}
 
 	// Invalidate cache after write
@@ -456,6 +485,56 @@ func (s FgaService) writeAndDeleteTuplesBatch(
 	).InfoContext(ctx, "wrote and deleted tuples")
 
 	return nil
+}
+
+// extractInvalidTuple extracts the tuple string from an OpenFGA validation error.
+// Returns the tuple string (e.g. "object:id#relation@user:id") and true if the
+// error is a validation_error containing an invalid tuple message.
+func extractInvalidTuple(err error) (string, bool) {
+	var validationErr openfga.FgaApiValidationError
+	if !errors.As(err, &validationErr) {
+		return "", false
+	}
+	msg := validationErr.Error()
+	const prefix = "Invalid tuple '"
+	start := strings.Index(msg, prefix)
+	if start == -1 {
+		return "", false
+	}
+	start += len(prefix)
+	end := strings.Index(msg[start:], "'")
+	if end == -1 {
+		return "", false
+	}
+	return msg[start : start+end], true
+}
+
+// removeInvalidWriteTuple returns a new slice with the first write tuple matching
+// tupleStr removed. Returns the original slice and false if no match is found.
+func removeInvalidWriteTuple(writes []ClientTupleKey, tupleStr string) ([]ClientTupleKey, bool) {
+	for i, t := range writes {
+		if t.Object+"#"+t.Relation+"@"+t.User == tupleStr {
+			result := make([]ClientTupleKey, 0, len(writes)-1)
+			result = append(result, writes[:i]...)
+			result = append(result, writes[i+1:]...)
+			return result, true
+		}
+	}
+	return writes, false
+}
+
+// removeInvalidDeleteTuple returns a new slice with the first delete tuple matching
+// tupleStr removed. Returns the original slice and false if no match is found.
+func removeInvalidDeleteTuple(deletes []ClientTupleKeyWithoutCondition, tupleStr string) ([]ClientTupleKeyWithoutCondition, bool) {
+	for i, t := range deletes {
+		if t.Object+"#"+t.Relation+"@"+t.User == tupleStr {
+			result := make([]ClientTupleKeyWithoutCondition, 0, len(deletes)-1)
+			result = append(result, deletes[:i]...)
+			result = append(result, deletes[i+1:]...)
+			return result, true
+		}
+	}
+	return deletes, false
 }
 
 // WriteTuples writes the given tuples to OpenFGA without reading or comparing existing tuples.

--- a/fga_test.go
+++ b/fga_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base32"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -1412,6 +1413,154 @@ func TestSyncObjectTuples_ExcludeRelations(t *testing.T) {
 			}
 
 			// Verify all expectations were met
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+// makeValidationError creates an openfga.FgaApiValidationError containing the given message.
+func makeValidationError(message string) openfga.FgaApiValidationError {
+	req, _ := http.NewRequest("POST", "http://localhost:8080", nil) //nolint:noctx
+	resp := &http.Response{
+		StatusCode: 422,
+		Header:     http.Header{},
+		Request:    req,
+	}
+	body := []byte(`{"code":"validation_error","message":"` + message + `"}`)
+	return openfga.NewFgaApiValidationError("Write", nil, resp, body, "store-id")
+}
+
+func TestWriteAndDeleteTuplesBatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		writes      []ClientTupleKey
+		deletes     []ClientTupleKeyWithoutCondition
+		mockSetup   func(*MockFgaClient)
+		expectError bool
+		description string
+	}{
+		{
+			name: "invalid write tuple skipped and retry succeeds",
+			writes: []ClientTupleKey{
+				{Object: "project:5e88f157", Relation: "executive_director", User: "user:alice"},
+				{Object: "project:5e88f157", Relation: "viewer", User: "user:*"},
+			},
+			deletes: nil,
+			mockSetup: func(m *MockFgaClient) {
+				// First call fails with invalid tuple error for executive_director
+				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+					return len(req.Writes) == 2
+				})).Return((*ClientWriteResponse)(nil),
+					makeValidationError("Invalid tuple 'project:5e88f157#executive_director@user:alice'. Reason: relation 'project#executive_director' not found"),
+				).Once()
+				// Retry with only the valid tuple succeeds
+				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+					return len(req.Writes) == 1 && req.Writes[0].Relation == "viewer"
+				})).Return(&ClientWriteResponse{}, nil).Once()
+			},
+			expectError: false,
+			description: "invalid write tuple should be removed and batch retried",
+		},
+		{
+			name:   "invalid delete tuple skipped and retry succeeds",
+			writes: nil,
+			deletes: []ClientTupleKeyWithoutCondition{
+				{Object: "vote_response:abc", Relation: "project", User: "project:123"},
+				{Object: "vote_response:abc", Relation: "viewer", User: "user:bob"},
+			},
+			mockSetup: func(m *MockFgaClient) {
+				// First call fails with invalid tuple error
+				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+					return len(req.Deletes) == 2
+				})).Return((*ClientWriteResponse)(nil),
+					makeValidationError("Invalid tuple 'vote_response:abc#project@project:123'. Reason: relation 'vote_response#project' not found"),
+				).Once()
+				// Retry with only the valid delete tuple succeeds
+				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+					return len(req.Deletes) == 1 && req.Deletes[0].Relation == "viewer"
+				})).Return(&ClientWriteResponse{}, nil).Once()
+			},
+			expectError: false,
+			description: "invalid delete tuple should be removed and batch retried",
+		},
+		{
+			name: "all write tuples invalid returns nil",
+			writes: []ClientTupleKey{
+				{Object: "project:123", Relation: "executive_director", User: "user:alice"},
+			},
+			deletes: nil,
+			mockSetup: func(m *MockFgaClient) {
+				m.On("Write", mock.Anything, mock.Anything).Return((*ClientWriteResponse)(nil),
+					makeValidationError("Invalid tuple 'project:123#executive_director@user:alice'. Reason: relation 'project#executive_director' not found"),
+				).Once()
+			},
+			expectError: false,
+			description: "when all tuples are invalid the batch should succeed with no writes",
+		},
+		{
+			name: "non-validation error returned as-is",
+			writes: []ClientTupleKey{
+				{Object: "project:123", Relation: "viewer", User: "user:alice"},
+			},
+			deletes: nil,
+			mockSetup: func(m *MockFgaClient) {
+				m.On("Write", mock.Anything, mock.Anything).
+					Return((*ClientWriteResponse)(nil), errors.New("network error")).Once()
+			},
+			expectError: true,
+			description: "non-validation errors should be returned unchanged",
+		},
+		{
+			name: "multiple invalid tuples removed one by one",
+			writes: []ClientTupleKey{
+				{Object: "project:abc", Relation: "executive_director", User: "user:alice"},
+				{Object: "project:abc", Relation: "technical_advisor", User: "user:bob"},
+				{Object: "project:abc", Relation: "viewer", User: "user:*"},
+			},
+			deletes: nil,
+			mockSetup: func(m *MockFgaClient) {
+				// First call: 3 writes, fail on executive_director
+				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+					return len(req.Writes) == 3
+				})).Return((*ClientWriteResponse)(nil),
+					makeValidationError("Invalid tuple 'project:abc#executive_director@user:alice'. Reason: relation 'project#executive_director' not found"),
+				).Once()
+				// Second call: 2 writes, fail on technical_advisor
+				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+					return len(req.Writes) == 2
+				})).Return((*ClientWriteResponse)(nil),
+					makeValidationError("Invalid tuple 'project:abc#technical_advisor@user:bob'. Reason: relation 'project#technical_advisor' not found"),
+				).Once()
+				// Third call: 1 write (viewer), succeeds
+				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+					return len(req.Writes) == 1 && req.Writes[0].Relation == "viewer"
+				})).Return(&ClientWriteResponse{}, nil).Once()
+			},
+			expectError: false,
+			description: "multiple invalid tuples should each be removed and batch retried",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := new(MockFgaClient)
+			mockCache := NewMockKeyValue()
+			tt.mockSetup(mockClient)
+
+			service := FgaService{
+				client:      mockClient,
+				cacheBucket: mockCache,
+			}
+
+			err := service.writeAndDeleteTuplesBatch(context.Background(), tt.writes, tt.deletes)
+
+			if tt.expectError && err == nil {
+				t.Errorf("%s: expected error but got nil", tt.description)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("%s: unexpected error: %v", tt.description, err)
+			}
+
 			mockClient.AssertExpectations(t)
 		})
 	}


### PR DESCRIPTION
## Summary

- When OpenFGA returns a `validation_error` for an invalid tuple, remove that tuple and retry the batch rather than failing the entire write
- Valid tuples in the same batch now succeed; invalid ones are logged as warnings and skipped
- Adds helpers: `extractInvalidTuple`, `removeInvalidWriteTuple`, `removeInvalidDeleteTuple`

## Problem

2,711 failures/24h in production caused by relations that don't exist in the OpenFGA model:

| Object type | Failures/24h | Invalid relations |
|---|---|---|
| `vote_response` | 2,658 | `project`, `viewer`, `writer` |
| `project` | 51 | `executive_director` |

Before this fix, the entire batch failed — leaving affected objects with no FGA tuples at all.

## Changes

**`fga.go`** — `writeAndDeleteTuplesBatch` wraps the write in a retry loop:
1. On `FgaApiValidationError`, parse `Invalid tuple '...'` from the error message
2. Remove the matching tuple from writes or deletes
3. Log a warning with `skipped_tuple`
4. Retry; if all tuples are exhausted return `nil`

**`fga_test.go`** — `TestWriteAndDeleteTuplesBatch` covers 5 cases:
- Invalid write tuple skipped → retry succeeds
- Invalid delete tuple skipped → retry succeeds
- All tuples invalid → returns `nil`
- Non-validation error → returned unchanged
- Multiple invalid tuples removed one by one

## Test plan

- [x] `make test` passes
- [ ] Deploy to production and verify `failed to sync tuples` errors become `skipping invalid tuple and retrying batch write` warnings

Closes LFXV2-1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)