### PR TITLE
feat: add lf-staff/lf-contractor LDAP → OpenFGA global team sync script

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -80,7 +80,8 @@
     "unmarshals",
     "uids",
     "tracecontext",
-    "GOTOOLCHAIN"
+    "GOTOOLCHAIN",
+    "datadoghq"
   ],
   "overrides": [
     {

--- a/scripts/sync_global_groups/cronjob.yaml
+++ b/scripts/sync_global_groups/cronjob.yaml
@@ -24,6 +24,9 @@ spec:
       ttlSecondsAfterFinished: 3600
       backoffLimit: 0
       template:
+        metadata:
+          annotations:
+            ad.datadoghq.com/sync.logs: '[{"service": "lfx-v2-fga-sync", "source": "go"}]'
         spec:
           restartPolicy: Never
           volumes:

--- a/scripts/sync_global_groups/cronjob.yaml
+++ b/scripts/sync_global_groups/cronjob.yaml
@@ -1,0 +1,61 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+# cronjob.yaml runs the sync_global_groups script on a schedule inside the
+# cluster. Before applying:
+#   1. Run deploy-configmap.sh to push the latest script as a ConfigMap.
+#   2. Replace all REPLACE_ME values with environment-specific values.
+#   3. Create the fga-sync-global-groups-client-secrets-ad-hoc Secret with
+#      client_id and client_secret keys.
+#
+# Apply with: kubectl apply -f cronjob.yaml -n lfx
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-global-groups-ad-hoc
+  namespace: lfx
+spec:
+  schedule: "*/10 * * * *"   # Every 10 minutes.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          volumes:
+            - name: script
+              configMap:
+                name: sync-global-groups-ad-hoc
+          containers:
+            - name: sync
+              image: golang:1.26-alpine
+              command:
+                - go
+                - run
+                - /script/main.go
+              volumeMounts:
+                - name: script
+                  mountPath: /script
+              env:
+                - name: CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: fga-sync-global-groups-client-secrets-ad-hoc
+                      key: client_id
+                - name: CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: fga-sync-global-groups-client-secrets-ad-hoc
+                      key: client_secret
+                - name: LDAP_REST_PROXY
+                  value: "REPLACE_ME"   # e.g. https://ldap-rest-proxy.example.com
+                - name: OAUTH_TOKEN_ENDPOINT
+                  value: "REPLACE_ME"   # e.g. https://auth.example.com/oauth/token
+                - name: OPENFGA_API_URL
+                  value: "REPLACE_ME"   # e.g. http://lfx-platform-openfga.lfx.svc.cluster.local:8080
+                - name: OPENFGA_STORE_ID
+                  value: "REPLACE_ME"   # OpenFGA store ID

--- a/scripts/sync_global_groups/cronjob.yaml
+++ b/scripts/sync_global_groups/cronjob.yaml
@@ -25,6 +25,8 @@ spec:
       backoffLimit: 0
       template:
         metadata:
+          labels:
+            tags.datadoghq.com/service: lfx-v2-fga-sync
           annotations:
             ad.datadoghq.com/sync.logs: '[{"service": "lfx-v2-fga-sync", "source": "go"}]'
         spec:

--- a/scripts/sync_global_groups/cronjob.yaml
+++ b/scripts/sync_global_groups/cronjob.yaml
@@ -37,7 +37,7 @@ spec:
                 name: sync-global-groups-ad-hoc
           containers:
             - name: sync
-              image: golang:1.26-alpine
+              image: golang:1.24-alpine
               command:
                 - go
                 - run

--- a/scripts/sync_global_groups/deploy-configmap.sh
+++ b/scripts/sync_global_groups/deploy-configmap.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+# deploy-configmap.sh wraps scripts/sync_global_groups/main.go as a Kubernetes
+# ConfigMap and applies it to the cluster. The ConfigMap is intended for use
+# with the accompanying cronjob.yaml.
+#
+# Usage: ./deploy-configmap.sh [namespace]
+#   namespace  Target Kubernetes namespace (default: lfx)
+
+set -euo pipefail
+
+NAMESPACE="${1:-lfx}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_FILE="${SCRIPT_DIR}/main.go"
+CONFIGMAP_NAME="sync-global-groups-ad-hoc"
+
+# Support KUBECTL_CONTEXT env var to select a kubeconfig context.
+KUBECTL_ARGS=()
+if [[ -n "${KUBECTL_CONTEXT:-}" ]]; then
+  KUBECTL_ARGS+=(--context "${KUBECTL_CONTEXT}")
+fi
+
+echo "Deploying ConfigMap '${CONFIGMAP_NAME}' to namespace '${NAMESPACE}'..."
+
+kubectl "${KUBECTL_ARGS[@]}" create configmap "${CONFIGMAP_NAME}" \
+  --from-file=main.go="${SCRIPT_FILE}" \
+  --namespace="${NAMESPACE}" \
+  --dry-run=client -o yaml \
+  | kubectl "${KUBECTL_ARGS[@]}" apply -f -
+
+echo "Done."

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -433,7 +433,6 @@ func main() {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
 
 	// groups maps LDAP group names to OpenFGA team object names.
 	groups := [][2]string{
@@ -448,8 +447,8 @@ func main() {
 			failed = true
 		}
 	}
+	cancel()
 	if failed {
-		cancel()
 		os.Exit(1)
 	}
 }

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -207,8 +207,11 @@ func fgaTeamMembers(ctx context.Context, teamObject string) (map[string]string, 
 		for _, t := range fgaResp.Tuples {
 			user := t.Key.User
 			// Only consider "user:" subjects; ignore wildcards or other types.
+			// Strip the "user:" prefix, then strip the "auth0|" prefix added by
+			// usernameToSub so the key matches the raw LDAP username for diffing.
 			if after, ok := strings.CutPrefix(user, "user:"); ok {
-				result[strings.ToLower(after)] = after
+				username, _ := strings.CutPrefix(after, "auth0|")
+				result[strings.ToLower(username)] = after
 			}
 		}
 
@@ -320,7 +323,8 @@ func syncGroup(ctx context.Context, ldapGroup, fgaTeamObject string) error {
 		"object", fgaTeamObject,
 		"count", len(fgaMembers))
 
-	var toAdd, toRemove []fgaTupleKey
+	toAdd := make([]fgaTupleKey, 0, len(ldapMembers))
+	toRemove := make([]fgaTupleKey, 0, len(fgaMembers))
 
 	for lower, original := range ldapMembers {
 		if _, ok := fgaMembers[lower]; !ok {

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -71,13 +71,13 @@ func fetchToken(ctx context.Context) (*token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		data, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token request returned %d: %s", resp.StatusCode, data)
+		return nil, fmt.Errorf("token request returned %d", resp.StatusCode)
 	}
 	var t token
-	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
+	if err := json.Unmarshal(data, &t); err != nil {
 		return nil, fmt.Errorf("decode token: %w", err)
 	}
 	refreshSkew := 30.0
@@ -158,8 +158,9 @@ type fgaReadResponse struct {
 	ContinuationToken string `json:"continuation_token"`
 }
 
-// fgaTeamMembers returns a map of lowercase username → original username for
-// all "user:" subjects with the "member" relation to the given team object.
+// fgaTeamMembers returns a map of lowercase username → OpenFGA subject without
+// the "user:" prefix (e.g. "auth0|username") for all "user:auth0|..." subjects
+// with the "member" relation to the given team object.
 func fgaTeamMembers(ctx context.Context, teamObject string) (map[string]string, error) {
 	if openfgaStoreID == "" {
 		return nil, fmt.Errorf("OPENFGA_STORE_ID is required")
@@ -200,9 +201,8 @@ func fgaTeamMembers(ctx context.Context, teamObject string) (map[string]string, 
 		resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("OpenFGA returned %d: %s", resp.StatusCode, body)
+			return nil, fmt.Errorf("OpenFGA returned %d", resp.StatusCode)
 		}
-
 		var fgaResp fgaReadResponse
 		if err := json.Unmarshal(body, &fgaResp); err != nil {
 			return nil, fmt.Errorf("decode OpenFGA response: %w", err)
@@ -210,12 +210,11 @@ func fgaTeamMembers(ctx context.Context, teamObject string) (map[string]string, 
 
 		for _, t := range fgaResp.Tuples {
 			user := t.Key.User
-			// Only consider "user:" subjects; ignore wildcards or other types.
-			// Strip the "user:" prefix, then strip the "auth0|" prefix added by
-			// usernameToSub so the key matches the raw LDAP username for diffing.
-			if after, ok := strings.CutPrefix(user, "user:"); ok {
-				username, _ := strings.CutPrefix(after, "auth0|")
-				result[strings.ToLower(username)] = after
+			// Only consider "user:auth0|..." subjects — the format written by
+			// usernameToSub. Ignore wildcards, other subject types, and users
+			// from other identity providers so they are not unintentionally removed.
+			if after, ok := strings.CutPrefix(user, "user:auth0|"); ok {
+				result[strings.ToLower(after)] = "auth0|" + after
 			}
 		}
 
@@ -270,10 +269,10 @@ func fgaWrite(ctx context.Context, writes, deletes []fgaTupleKey) error {
 			if err != nil {
 				return fmt.Errorf("OpenFGA write request: %w", err)
 			}
-			body, _ := io.ReadAll(resp.Body)
+			_, _ = io.ReadAll(resp.Body)
 			resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
-				return fmt.Errorf("OpenFGA write returned %d: %s", resp.StatusCode, body)
+				return fmt.Errorf("OpenFGA write returned %d", resp.StatusCode)
 			}
 		}
 		return nil

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -1,0 +1,421 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// sync_global_groups syncs LDAP global groups to corresponding OpenFGA team
+// member tuples, adding and removing "user:" relations as needed.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Configuration read from environment variables.
+var (
+	ldapRestProxy      = os.Getenv("LDAP_REST_PROXY")
+	oauthTokenEndpoint = os.Getenv("OAUTH_TOKEN_ENDPOINT")
+	clientID           = os.Getenv("CLIENT_ID")
+	clientSecret       = os.Getenv("CLIENT_SECRET")
+	openfgaURL         = os.Getenv("OPENFGA_API_URL")
+	openfgaStoreID     = os.Getenv("OPENFGA_STORE_ID")
+	debug              = isTruthy(os.Getenv("DEBUG"))
+	dryRun             = isTruthy(os.Getenv("DRYRUN"))
+)
+
+// isTruthy returns true if the value is a common truthy string.
+func isTruthy(v string) bool {
+	switch strings.ToLower(v) {
+	case "1", "t", "y", "true", "yes":
+		return true
+	}
+	return false
+}
+
+// token holds an OAuth2 client_credentials token.
+type token struct {
+	AccessToken string  `json:"access_token"`
+	ExpiresIn   float64 `json:"expires_in"`
+	expiresAt   time.Time
+}
+
+var (
+	currentToken *token
+	httpClient   = &http.Client{Timeout: 30 * time.Second}
+)
+
+// fetchToken retrieves a new client_credentials token from the OAuth token endpoint.
+func fetchToken() (*token, error) {
+	audience := ldapRestProxy
+	body := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"audience":      {audience},
+	}
+	resp, err := httpClient.PostForm(oauthTokenEndpoint, body)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token request returned %d: %s", resp.StatusCode, data)
+	}
+	var t token
+	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
+		return nil, fmt.Errorf("decode token: %w", err)
+	}
+	t.expiresAt = time.Now().Add(time.Duration(t.ExpiresIn-30) * time.Second)
+	return &t, nil
+}
+
+// ldapBearerToken returns a valid bearer token for the LDAP REST proxy.
+func ldapBearerToken() (string, error) {
+	if currentToken == nil || time.Now().After(currentToken.expiresAt) {
+		t, err := fetchToken()
+		if err != nil {
+			return "", err
+		}
+		currentToken = t
+	}
+	return currentToken.AccessToken, nil
+}
+
+// ldapGroupMembers returns a map of lowercase username → original username for
+// all members of the given LDAP group.
+func ldapGroupMembers(group string) (map[string]string, error) {
+	bearer, err := ldapBearerToken()
+	if err != nil {
+		return nil, err
+	}
+	reqURL := strings.TrimRight(ldapRestProxy, "/") + "/groups/" + url.PathEscape(group)
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("LDAP request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("LDAP returned %d: %s", resp.StatusCode, data)
+	}
+
+	var usernames []string
+	if err := json.NewDecoder(resp.Body).Decode(&usernames); err != nil {
+		return nil, fmt.Errorf("decode LDAP response: %w", err)
+	}
+
+	result := make(map[string]string, len(usernames))
+	for _, u := range usernames {
+		result[strings.ToLower(u)] = u
+	}
+	return result, nil
+}
+
+// fgaReadRequest is the request body for the OpenFGA Read API.
+type fgaReadRequest struct {
+	TupleKey          fgaTupleKey `json:"tuple_key"`
+	PageSize          int         `json:"page_size"`
+	ContinuationToken string      `json:"continuation_token,omitempty"`
+}
+
+// fgaTupleKey identifies a relationship triple.
+type fgaTupleKey struct {
+	User     string `json:"user,omitempty"`
+	Relation string `json:"relation,omitempty"`
+	Object   string `json:"object,omitempty"`
+}
+
+// fgaReadResponse is the response body from the OpenFGA Read API.
+type fgaReadResponse struct {
+	Tuples []struct {
+		Key fgaTupleKey `json:"key"`
+	} `json:"tuples"`
+	ContinuationToken string `json:"continuation_token"`
+}
+
+// fgaTeamMembers returns a map of lowercase username → original username for
+// all "user:" subjects with the "member" relation to the given team object.
+func fgaTeamMembers(teamObject string) (map[string]string, error) {
+	if openfgaStoreID == "" {
+		return nil, fmt.Errorf("OPENFGA_STORE_ID is required")
+	}
+	endpoint := fmt.Sprintf("%s/stores/%s/read", strings.TrimRight(openfgaURL, "/"), openfgaStoreID)
+
+	result := make(map[string]string)
+	var contToken string
+
+	for {
+		reqBody := fgaReadRequest{
+			TupleKey: fgaTupleKey{
+				Relation: "member",
+				Object:   teamObject,
+			},
+			PageSize: 100,
+		}
+		if contToken != "" {
+			reqBody.ContinuationToken = contToken
+		}
+
+		data, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request: %w", err)
+		}
+
+		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("OpenFGA request: %w", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("OpenFGA returned %d: %s", resp.StatusCode, body)
+		}
+
+		var fgaResp fgaReadResponse
+		if err := json.Unmarshal(body, &fgaResp); err != nil {
+			return nil, fmt.Errorf("decode OpenFGA response: %w", err)
+		}
+
+		for _, t := range fgaResp.Tuples {
+			user := t.Key.User
+			// Only consider "user:" subjects; ignore wildcards or other types.
+			if after, ok := strings.CutPrefix(user, "user:"); ok {
+				result[strings.ToLower(after)] = after
+			}
+		}
+
+		if fgaResp.ContinuationToken == "" {
+			break
+		}
+		contToken = fgaResp.ContinuationToken
+	}
+
+	return result, nil
+}
+
+// fgaWriteRequest is the request body for the OpenFGA Write API.
+type fgaWriteRequest struct {
+	Writes  *fgaTupleKeys `json:"writes,omitempty"`
+	Deletes *fgaTupleKeys `json:"deletes,omitempty"`
+}
+
+// fgaTupleKeys is a list of tuple keys for the OpenFGA Write API.
+type fgaTupleKeys struct {
+	TupleKeys []fgaTupleKey `json:"tuple_keys"`
+}
+
+// fgaWrite writes or deletes tuples in OpenFGA.
+func fgaWrite(writes, deletes []fgaTupleKey) error {
+	endpoint := fmt.Sprintf("%s/stores/%s/write", strings.TrimRight(openfgaURL, "/"), openfgaStoreID)
+
+	// OpenFGA write API accepts at most 100 tuples per request; batch if needed.
+	batch := func(keys []fgaTupleKey, isWrite bool) error {
+		for i := 0; i < len(keys); i += 100 {
+			end := i + 100
+			if end > len(keys) {
+				end = len(keys)
+			}
+			chunk := keys[i:end]
+			reqBody := fgaWriteRequest{}
+			if isWrite {
+				reqBody.Writes = &fgaTupleKeys{TupleKeys: chunk}
+			} else {
+				reqBody.Deletes = &fgaTupleKeys{TupleKeys: chunk}
+			}
+			data, err := json.Marshal(reqBody)
+			if err != nil {
+				return fmt.Errorf("marshal request: %w", err)
+			}
+			req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
+			if err != nil {
+				return fmt.Errorf("build request: %w", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				return fmt.Errorf("OpenFGA write request: %w", err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("OpenFGA write returned %d: %s", resp.StatusCode, body)
+			}
+		}
+		return nil
+	}
+
+	if len(writes) > 0 {
+		if err := batch(writes, true); err != nil {
+			return err
+		}
+	}
+	if len(deletes) > 0 {
+		if err := batch(deletes, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// usernameRegexp matches valid LDAP usernames that can be converted to Auth0
+// subject IDs by prepending "auth0|".
+var usernameRegexp = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,58}[A-Za-z0-9]$`)
+
+// usernameToSub converts an LDAP username to an Auth0 subject ID. It returns
+// an error if the username does not match the expected pattern, in which case
+// the caller should skip the user.
+func usernameToSub(username string) (string, error) {
+	if !usernameRegexp.MatchString(username) {
+		return "", fmt.Errorf("username %q does not match expected pattern; skipping", username)
+	}
+	return "auth0|" + username, nil
+}
+
+// syncGroup syncs the members of an LDAP group to the corresponding OpenFGA
+// team object, adding and removing tuples as needed.
+func syncGroup(ldapGroup, fgaTeamObject string) error {
+	slog.Debug("fetching members from LDAP", "group", ldapGroup)
+	ldapMembers, err := ldapGroupMembers(ldapGroup)
+	if err != nil {
+		return fmt.Errorf("LDAP error for %s: %w", ldapGroup, err)
+	}
+	slog.Debug("fetched LDAP group members",
+		"group", ldapGroup,
+		"count", len(ldapMembers))
+
+	slog.Debug("fetching members from OpenFGA", "object", fgaTeamObject)
+	fgaMembers, err := fgaTeamMembers(fgaTeamObject)
+	if err != nil {
+		return fmt.Errorf("OpenFGA error for %s: %w", fgaTeamObject, err)
+	}
+	slog.Debug("fetched OpenFGA team members",
+		"object", fgaTeamObject,
+		"count", len(fgaMembers))
+
+	var toAdd, toRemove []fgaTupleKey
+
+	for lower, original := range ldapMembers {
+		if _, ok := fgaMembers[lower]; !ok {
+			sub, err := usernameToSub(original)
+			if err != nil {
+				slog.Warn("skipping user", "username", original, "reason", err.Error())
+				continue
+			}
+			toAdd = append(toAdd, fgaTupleKey{
+				User:     "user:" + sub,
+				Relation: "member",
+				Object:   fgaTeamObject,
+			})
+		}
+	}
+	for lower, original := range fgaMembers {
+		if _, ok := ldapMembers[lower]; !ok {
+			toRemove = append(toRemove, fgaTupleKey{
+				User:     "user:" + original,
+				Relation: "member",
+				Object:   fgaTeamObject,
+			})
+		}
+	}
+
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		slog.Debug("already in sync", "object", fgaTeamObject)
+		return nil
+	}
+
+	for _, t := range toAdd {
+		slog.Info("adding member", "user", t.User, "object", fgaTeamObject)
+	}
+	for _, t := range toRemove {
+		slog.Info("removing member", "user", t.User, "object", fgaTeamObject)
+	}
+
+	if dryRun {
+		slog.Info("dry run; skipping write",
+			"object", fgaTeamObject,
+			"would_add", len(toAdd),
+			"would_remove", len(toRemove))
+		return nil
+	}
+
+	if err := fgaWrite(toAdd, toRemove); err != nil {
+		return fmt.Errorf("write error for %s: %w", fgaTeamObject, err)
+	}
+	slog.Info("sync complete",
+		"object", fgaTeamObject,
+		"added", len(toAdd),
+		"removed", len(toRemove))
+	return nil
+}
+
+func main() {
+	level := slog.LevelInfo
+	if debug {
+		level = slog.LevelDebug
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+
+	if ldapRestProxy == "" {
+		slog.Error("LDAP_REST_PROXY is required")
+		os.Exit(1)
+	}
+	if oauthTokenEndpoint == "" {
+		slog.Error("OAUTH_TOKEN_ENDPOINT is required")
+		os.Exit(1)
+	}
+	if clientID == "" {
+		slog.Error("CLIENT_ID is required")
+		os.Exit(1)
+	}
+	if clientSecret == "" {
+		slog.Error("CLIENT_SECRET is required")
+		os.Exit(1)
+	}
+	if openfgaURL == "" {
+		slog.Error("OPENFGA_API_URL is required")
+		os.Exit(1)
+	}
+	if openfgaStoreID == "" {
+		slog.Error("OPENFGA_STORE_ID is required")
+		os.Exit(1)
+	}
+
+	// groups maps LDAP group names to OpenFGA team object names.
+	groups := [][2]string{
+		{"lf-staff", "team:lf-staff"},
+		{"lf-contractor", "team:lf-contractor"},
+	}
+
+	var failed bool
+	for _, g := range groups {
+		if err := syncGroup(g[0], g[1]); err != nil {
+			slog.Error("sync failed", "group", g[0], "error", err.Error())
+			failed = true
+		}
+	}
+	if failed {
+		os.Exit(1)
+	}
+}

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -311,7 +311,7 @@ var usernameRegexp = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,58}[A-Za-z
 // the caller should skip the user.
 func usernameToSub(username string) (string, error) {
 	if !usernameRegexp.MatchString(username) {
-		return "", fmt.Errorf("username %q does not match expected pattern; skipping", username)
+		return "", fmt.Errorf("username %q does not match expected pattern", username)
 	}
 	return "auth0|" + username, nil
 }

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -80,7 +80,11 @@ func fetchToken(ctx context.Context) (*token, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
 		return nil, fmt.Errorf("decode token: %w", err)
 	}
-	t.expiresAt = time.Now().Add(time.Duration(t.ExpiresIn-30) * time.Second)
+	refreshSkew := 30.0
+	if t.ExpiresIn <= refreshSkew {
+		refreshSkew = t.ExpiresIn / 2
+	}
+	t.expiresAt = time.Now().Add(time.Duration((t.ExpiresIn - refreshSkew) * float64(time.Second)))
 	return &t, nil
 }
 

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -197,11 +197,14 @@ func fgaTeamMembers(ctx context.Context, teamObject string) (map[string]string, 
 		if err != nil {
 			return nil, fmt.Errorf("OpenFGA request: %w", err)
 		}
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read OpenFGA response body: %w", err)
+		}
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("OpenFGA returned %d", resp.StatusCode)
+			return nil, fmt.Errorf("OpenFGA returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 		}
 		var fgaResp fgaReadResponse
 		if err := json.Unmarshal(body, &fgaResp); err != nil {
@@ -269,10 +272,18 @@ func fgaWrite(ctx context.Context, writes, deletes []fgaTupleKey) error {
 			if err != nil {
 				return fmt.Errorf("OpenFGA write request: %w", err)
 			}
-			_, _ = io.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
+			if err != nil {
+				return fmt.Errorf("read OpenFGA write response body: %w", err)
+			}
 			if resp.StatusCode != http.StatusOK {
-				return fmt.Errorf("OpenFGA write returned %d", resp.StatusCode)
+				const maxBody = 1024
+				bodyText := strings.TrimSpace(string(body))
+				if len(bodyText) > maxBody {
+					bodyText = bodyText[:maxBody] + "...(truncated)"
+				}
+				return fmt.Errorf("OpenFGA write returned %d: %s", resp.StatusCode, bodyText)
 			}
 		}
 		return nil

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -53,7 +54,7 @@ var (
 )
 
 // fetchToken retrieves a new client_credentials token from the OAuth token endpoint.
-func fetchToken() (*token, error) {
+func fetchToken(ctx context.Context) (*token, error) {
 	audience := ldapRestProxy
 	body := url.Values{
 		"grant_type":    {"client_credentials"},
@@ -61,7 +62,12 @@ func fetchToken() (*token, error) {
 		"client_secret": {clientSecret},
 		"audience":      {audience},
 	}
-	resp, err := httpClient.PostForm(oauthTokenEndpoint, body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, oauthTokenEndpoint, strings.NewReader(body.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}
@@ -79,9 +85,9 @@ func fetchToken() (*token, error) {
 }
 
 // ldapBearerToken returns a valid bearer token for the LDAP REST proxy.
-func ldapBearerToken() (string, error) {
+func ldapBearerToken(ctx context.Context) (string, error) {
 	if currentToken == nil || time.Now().After(currentToken.expiresAt) {
-		t, err := fetchToken()
+		t, err := fetchToken(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -92,13 +98,13 @@ func ldapBearerToken() (string, error) {
 
 // ldapGroupMembers returns a map of lowercase username → original username for
 // all members of the given LDAP group.
-func ldapGroupMembers(group string) (map[string]string, error) {
-	bearer, err := ldapBearerToken()
+func ldapGroupMembers(ctx context.Context, group string) (map[string]string, error) {
+	bearer, err := ldapBearerToken(ctx)
 	if err != nil {
 		return nil, err
 	}
 	reqURL := strings.TrimRight(ldapRestProxy, "/") + "/groups/" + url.PathEscape(group)
-	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -150,7 +156,7 @@ type fgaReadResponse struct {
 
 // fgaTeamMembers returns a map of lowercase username → original username for
 // all "user:" subjects with the "member" relation to the given team object.
-func fgaTeamMembers(teamObject string) (map[string]string, error) {
+func fgaTeamMembers(ctx context.Context, teamObject string) (map[string]string, error) {
 	if openfgaStoreID == "" {
 		return nil, fmt.Errorf("OPENFGA_STORE_ID is required")
 	}
@@ -176,7 +182,7 @@ func fgaTeamMembers(teamObject string) (map[string]string, error) {
 			return nil, fmt.Errorf("marshal request: %w", err)
 		}
 
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
 		if err != nil {
 			return nil, fmt.Errorf("build request: %w", err)
 		}
@@ -227,7 +233,7 @@ type fgaTupleKeys struct {
 }
 
 // fgaWrite writes or deletes tuples in OpenFGA.
-func fgaWrite(writes, deletes []fgaTupleKey) error {
+func fgaWrite(ctx context.Context, writes, deletes []fgaTupleKey) error {
 	endpoint := fmt.Sprintf("%s/stores/%s/write", strings.TrimRight(openfgaURL, "/"), openfgaStoreID)
 
 	// OpenFGA write API accepts at most 100 tuples per request; batch if needed.
@@ -248,7 +254,7 @@ func fgaWrite(writes, deletes []fgaTupleKey) error {
 			if err != nil {
 				return fmt.Errorf("marshal request: %w", err)
 			}
-			req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
 			if err != nil {
 				return fmt.Errorf("build request: %w", err)
 			}
@@ -295,22 +301,22 @@ func usernameToSub(username string) (string, error) {
 
 // syncGroup syncs the members of an LDAP group to the corresponding OpenFGA
 // team object, adding and removing tuples as needed.
-func syncGroup(ldapGroup, fgaTeamObject string) error {
-	slog.Debug("fetching members from LDAP", "group", ldapGroup)
-	ldapMembers, err := ldapGroupMembers(ldapGroup)
+func syncGroup(ctx context.Context, ldapGroup, fgaTeamObject string) error {
+	slog.DebugContext(ctx, "fetching members from LDAP", "group", ldapGroup)
+	ldapMembers, err := ldapGroupMembers(ctx, ldapGroup)
 	if err != nil {
 		return fmt.Errorf("LDAP error for %s: %w", ldapGroup, err)
 	}
-	slog.Debug("fetched LDAP group members",
+	slog.DebugContext(ctx, "fetched LDAP group members",
 		"group", ldapGroup,
 		"count", len(ldapMembers))
 
-	slog.Debug("fetching members from OpenFGA", "object", fgaTeamObject)
-	fgaMembers, err := fgaTeamMembers(fgaTeamObject)
+	slog.DebugContext(ctx, "fetching members from OpenFGA", "object", fgaTeamObject)
+	fgaMembers, err := fgaTeamMembers(ctx, fgaTeamObject)
 	if err != nil {
 		return fmt.Errorf("OpenFGA error for %s: %w", fgaTeamObject, err)
 	}
-	slog.Debug("fetched OpenFGA team members",
+	slog.DebugContext(ctx, "fetched OpenFGA team members",
 		"object", fgaTeamObject,
 		"count", len(fgaMembers))
 
@@ -320,7 +326,7 @@ func syncGroup(ldapGroup, fgaTeamObject string) error {
 		if _, ok := fgaMembers[lower]; !ok {
 			sub, err := usernameToSub(original)
 			if err != nil {
-				slog.Warn("skipping user", "username", original, "reason", err.Error())
+				slog.WarnContext(ctx, "skipping user", "username", original, "reason", err.Error())
 				continue
 			}
 			toAdd = append(toAdd, fgaTupleKey{
@@ -341,29 +347,29 @@ func syncGroup(ldapGroup, fgaTeamObject string) error {
 	}
 
 	if len(toAdd) == 0 && len(toRemove) == 0 {
-		slog.Debug("already in sync", "object", fgaTeamObject)
+		slog.DebugContext(ctx, "already in sync", "object", fgaTeamObject)
 		return nil
 	}
 
 	for _, t := range toAdd {
-		slog.Info("adding member", "user", t.User, "object", fgaTeamObject)
+		slog.InfoContext(ctx, "adding member", "user", t.User, "object", fgaTeamObject)
 	}
 	for _, t := range toRemove {
-		slog.Info("removing member", "user", t.User, "object", fgaTeamObject)
+		slog.InfoContext(ctx, "removing member", "user", t.User, "object", fgaTeamObject)
 	}
 
 	if dryRun {
-		slog.Info("dry run; skipping write",
+		slog.InfoContext(ctx, "dry run; skipping write",
 			"object", fgaTeamObject,
 			"would_add", len(toAdd),
 			"would_remove", len(toRemove))
 		return nil
 	}
 
-	if err := fgaWrite(toAdd, toRemove); err != nil {
+	if err := fgaWrite(ctx, toAdd, toRemove); err != nil {
 		return fmt.Errorf("write error for %s: %w", fgaTeamObject, err)
 	}
-	slog.Info("sync complete",
+	slog.InfoContext(ctx, "sync complete",
 		"object", fgaTeamObject,
 		"added", len(toAdd),
 		"removed", len(toRemove))
@@ -402,6 +408,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
 	// groups maps LDAP group names to OpenFGA team object names.
 	groups := [][2]string{
 		{"lf-staff", "team:lf-staff"},
@@ -410,8 +419,8 @@ func main() {
 
 	var failed bool
 	for _, g := range groups {
-		if err := syncGroup(g[0], g[1]); err != nil {
-			slog.Error("sync failed", "group", g[0], "error", err.Error())
+		if err := syncGroup(ctx, g[0], g[1]); err != nil {
+			slog.ErrorContext(ctx, "sync failed", "group", g[0], "error", err.Error())
 			failed = true
 		}
 	}

--- a/scripts/sync_global_groups/main.go
+++ b/scripts/sync_global_groups/main.go
@@ -29,7 +29,7 @@ var (
 	openfgaURL         = os.Getenv("OPENFGA_API_URL")
 	openfgaStoreID     = os.Getenv("OPENFGA_STORE_ID")
 	debug              = isTruthy(os.Getenv("DEBUG"))
-	dryRun             = isTruthy(os.Getenv("DRYRUN"))
+	dryRun             = isTruthy(os.Getenv("DRY_RUN"))
 )
 
 // isTruthy returns true if the value is a common truthy string.
@@ -71,8 +71,11 @@ func fetchToken(ctx context.Context) (*token, error) {
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}
-	data, _ := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read token response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("token request returned %d", resp.StatusCode)
 	}
@@ -108,7 +111,7 @@ func ldapGroupMembers(ctx context.Context, group string) (map[string]string, err
 		return nil, err
 	}
 	reqURL := strings.TrimRight(ldapRestProxy, "/") + "/groups/" + url.PathEscape(group)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
@@ -120,7 +123,10 @@ func ldapGroupMembers(ctx context.Context, group string) (map[string]string, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		data, _ := io.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("LDAP returned %d (could not read body: %w)", resp.StatusCode, err)
+		}
 		return nil, fmt.Errorf("LDAP returned %d: %s", resp.StatusCode, data)
 	}
 
@@ -443,6 +449,7 @@ func main() {
 		}
 	}
 	if failed {
+		cancel()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `scripts/sync_global_groups/main.go` — a standalone Go script that syncs the `lf-staff` and `lf-contractor` LDAP groups into OpenFGA as `team:lf-staff` and `team:lf-contractor` member tuples
- Diffs current OpenFGA tuples against live LDAP membership and writes/deletes only what changed
- Supports `DRY_RUN` and `DEBUG` env vars; uses `slog` for JSON structured logging
- Passes a 5-minute `context.WithTimeout` through all HTTP requests to bound total execution time

## ROOT project auditor relation

The `team:lf-staff` and `team:lf-contractor` teams have already been written as `auditor` on the ROOT project as a one-time ad hoc action (consistent with how other ROOT-level grants are made). This script manages only ongoing team membership sync and does not re-assert that relation on each run.

## How to run

```sh
set -a && source scripts/sync_global_groups/.env && set +a
OPENFGA_API_URL=http://localhost:8080 OPENFGA_STORE_ID=<store-id> go run ./scripts/sync_global_groups/
```

## Kubernetes

A `CronJob` (every 10 minutes) and `ConfigMap` are deployed to the `lfx` namespace in prod. See `scripts/sync_global_groups/cronjob.yaml` and `deploy-configmap.sh`.

## Notes

- Script has no third-party dependencies; runs under the parent module (no separate `go.mod`), consistent with other scripts in this repo
- `.env` file is not committed (local secrets only)

## Jira

[LFXV2-1480](https://linuxfoundation.atlassian.net/browse/LFXV2-1480) — Instrument lf-staff and lf-contractor LDAP → OpenFGA global-team sync

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[LFXV2-1480]: https://linuxfoundation.atlassian.net/browse/LFXV2-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ