### PR TITLE
fix(otel): honor parent span sampling decisions

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -80,6 +80,8 @@
     "unmarshals",
     "uids",
     "tracecontext",
+    "traceidratio",
+    "parentbased",
     "GOTOOLCHAIN"
   ],
   "overrides": [
@@ -98,6 +100,7 @@
         "yml",
         "otel",
         "otlp",
+        "oteltrace",
         "semconv",
         "slogotel",
         "remychantenay",

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -95,7 +95,11 @@ spec:
             {{- if ne $otelTracesSampler "" }}
             - name: OTEL_TRACES_SAMPLER
               value: {{ $otelTracesSampler | quote }}
-            {{- if ne $otelTracesSampleRatio "" }}
+            {{- $otelTracesSamplerArg := .Values.application.otel.tracesSamplerArg | toString | trim }}
+            {{- if ne $otelTracesSamplerArg "" }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ $otelTracesSamplerArg | quote }}
+            {{- else if ne $otelTracesSampleRatio "" }}
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ $otelTracesSampleRatio | quote }}
             {{- end }}

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -86,11 +86,6 @@ spec:
             - name: OTEL_TRACES_EXPORTER
               value: {{ $otelTracesExporter | quote }}
             {{- end }}
-            {{- $otelTracesSampleRatio := .Values.application.otel.tracesSampleRatio | toString | trim }}
-            {{- if ne $otelTracesSampleRatio "" }}
-            - name: OTEL_TRACES_SAMPLE_RATIO
-              value: {{ $otelTracesSampleRatio | quote }}
-            {{- end }}
             {{- $otelTracesSampler := .Values.application.otel.tracesSampler | toString | trim }}
             {{- if ne $otelTracesSampler "" }}
             - name: OTEL_TRACES_SAMPLER
@@ -99,9 +94,6 @@ spec:
             {{- if ne $otelTracesSamplerArg "" }}
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ $otelTracesSamplerArg | quote }}
-            {{- else if ne $otelTracesSampleRatio "" }}
-            - name: OTEL_TRACES_SAMPLER_ARG
-              value: {{ $otelTracesSampleRatio | quote }}
             {{- end }}
             {{- end }}
             {{- $otelMetricsExporter := .Values.application.otel.metricsExporter | toString | trim }}

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -91,6 +91,15 @@ spec:
             - name: OTEL_TRACES_SAMPLE_RATIO
               value: {{ $otelTracesSampleRatio | quote }}
             {{- end }}
+            {{- $otelTracesSampler := .Values.application.otel.tracesSampler | toString | trim }}
+            {{- if ne $otelTracesSampler "" }}
+            - name: OTEL_TRACES_SAMPLER
+              value: {{ $otelTracesSampler | quote }}
+            {{- if ne $otelTracesSampleRatio "" }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ $otelTracesSampleRatio | quote }}
+            {{- end }}
+            {{- end }}
             {{- $otelMetricsExporter := .Values.application.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}
             - name: OTEL_METRICS_EXPORTER

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -90,11 +90,16 @@ spec:
             {{- if ne $otelTracesSampler "" }}
             - name: OTEL_TRACES_SAMPLER
               value: {{ $otelTracesSampler | quote }}
+            {{- end }}
             {{- $otelTracesSamplerArg := .Values.application.otel.tracesSamplerArg | toString | trim }}
             {{- if ne $otelTracesSamplerArg "" }}
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ $otelTracesSamplerArg | quote }}
             {{- end }}
+            {{- $otelTracesSampleRatio := .Values.application.otel.tracesSampleRatio | toString | trim }}
+            {{- if ne $otelTracesSampleRatio "" }}
+            - name: OTEL_TRACES_SAMPLE_RATIO
+              value: {{ $otelTracesSampleRatio | quote }}
             {{- end }}
             {{- $otelMetricsExporter := .Values.application.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}

--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -96,11 +96,6 @@ spec:
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ $otelTracesSamplerArg | quote }}
             {{- end }}
-            {{- $otelTracesSampleRatio := .Values.application.otel.tracesSampleRatio | toString | trim }}
-            {{- if ne $otelTracesSampleRatio "" }}
-            - name: OTEL_TRACES_SAMPLE_RATIO
-              value: {{ $otelTracesSampleRatio | quote }}
-            {{- end }}
             {{- $otelMetricsExporter := .Values.application.otel.metricsExporter | toString | trim }}
             {{- if ne $otelMetricsExporter "" }}
             - name: OTEL_METRICS_EXPORTER

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -130,6 +130,11 @@ application:
     # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
     # (default: "1.0")
     tracesSampleRatio: "1.0"
+    # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
+    # "always_on", "always_off", "traceidratio", "parentbased_always_on",
+    # "parentbased_always_off", "parentbased_traceidratio".
+    # When empty, the application defaults to parentbased_traceidratio.
+    tracesSampler: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -134,6 +134,11 @@ application:
     # tracesSamplerArg specifies the OTEL_TRACES_SAMPLER_ARG value for samplers
     # that require an argument (e.g., traceidratio samplers use a ratio 0.0-1.0).
     tracesSamplerArg: ""
+    # tracesSampleRatio is the sampling ratio for trace.TraceIDRatioBased sampler.
+    # Only used if OTEL_TRACES_SAMPLER is unset and OTEL_TRACES_SAMPLER_ARG is unset.
+    # (default: "1.0")
+    # Deprecated: Use tracesSamplerArg with tracesSampler instead.
+    tracesSampleRatio: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -134,11 +134,6 @@ application:
     # tracesSamplerArg specifies the OTEL_TRACES_SAMPLER_ARG value for samplers
     # that require an argument (e.g., traceidratio samplers use a ratio 0.0-1.0).
     tracesSamplerArg: ""
-    # tracesSampleRatio is the sampling ratio for trace.TraceIDRatioBased sampler.
-    # Only used if OTEL_TRACES_SAMPLER is unset and OTEL_TRACES_SAMPLER_ARG is unset.
-    # (default: "1.0")
-    # Deprecated: Use tracesSamplerArg with tracesSampler instead.
-    tracesSampleRatio: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -126,10 +126,6 @@ application:
     # tracesExporter specifies the traces exporter: "otlp" or "none"
     # (default: "none")
     tracesExporter: "none"
-    # tracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0)
-    # A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled
-    # (default: "1.0")
-    tracesSampleRatio: "1.0"
     # tracesSampler specifies the OTEL_TRACES_SAMPLER type. Supported values:
     # "always_on", "always_off", "traceidratio", "parentbased_always_on",
     # "parentbased_always_off", "parentbased_traceidratio".
@@ -137,7 +133,6 @@ application:
     tracesSampler: ""
     # tracesSamplerArg specifies the OTEL_TRACES_SAMPLER_ARG value for samplers
     # that require an argument (e.g., traceidratio samplers use a ratio 0.0-1.0).
-    # When empty, defaults to tracesSampleRatio for backward compatibility.
     tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -135,6 +135,10 @@ application:
     # "parentbased_always_off", "parentbased_traceidratio".
     # When empty, the application defaults to parentbased_traceidratio.
     tracesSampler: ""
+    # tracesSamplerArg specifies the OTEL_TRACES_SAMPLER_ARG value for samplers
+    # that require an argument (e.g., traceidratio samplers use a ratio 0.0-1.0).
+    # When empty, defaults to tracesSampleRatio for backward compatibility.
+    tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"
     # (default: "none")
     metricsExporter: "none"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 )
 
 require (
@@ -43,7 +44,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -309,28 +309,25 @@ func endpointURL(raw string, insecure bool) string {
 // a default ratio of 1.0 when sampler is unset. This ensures parent span
 // sampling decisions are always honored when no explicit sampler is configured.
 func newSampler(cfg OTelConfig) trace.Sampler {
-	sampler := cfg.TracesSampler
-	arg := cfg.TracesSamplerArg
-
 	parseRatio := func() float64 {
-		if arg != "" {
-			r, err := strconv.ParseFloat(arg, 64)
-			if err == nil && r >= 0.0 && r <= 1.0 {
-				return r
-			}
-			// Log parse error or range validation failure
-			if err != nil {
-				slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
-					"provided-value", arg, "error", err)
-			} else {
-				slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
-					"provided-value", arg)
-			}
+		if cfg.TracesSamplerArg == "" {
+			return 1.0
 		}
-		return 1.0
+		r, err := strconv.ParseFloat(cfg.TracesSamplerArg, 64)
+		if err != nil {
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
+				"provided-value", cfg.TracesSamplerArg, "error", err)
+			return 1.0
+		}
+		if r < 0.0 || r > 1.0 {
+			slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
+				"provided-value", cfg.TracesSamplerArg)
+			return 1.0
+		}
+		return r
 	}
 
-	switch sampler {
+	switch cfg.TracesSampler {
 	case otelSamplerAlwaysOn:
 		return trace.AlwaysSample()
 	case otelSamplerAlwaysOff:
@@ -347,7 +344,7 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	default: // unknown sampler type
 		slog.Warn("unknown OTEL_TRACES_SAMPLER value, defaulting to parentbased_traceidratio",
-			"value", sampler)
+			"value", cfg.TracesSampler)
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	}
 }

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -302,6 +302,43 @@ func endpointURL(raw string, insecure bool) string {
 	return "https://" + raw
 }
 
+// newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
+// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
+// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
+// This ensures parent span sampling decisions are always honored.
+func newSampler(cfg OTelConfig) trace.Sampler {
+	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
+	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+
+	parseRatio := func() float64 {
+		if arg != "" {
+			r, err := strconv.ParseFloat(arg, 64)
+			if err == nil && r >= 0.0 && r <= 1.0 {
+				return r
+			}
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+		}
+		return cfg.TracesSampleRatio
+	}
+
+	switch sampler {
+	case "always_on":
+		return trace.AlwaysSample()
+	case "always_off":
+		return trace.NeverSample()
+	case "traceidratio":
+		return trace.TraceIDRatioBased(parseRatio())
+	case "parentbased_always_on":
+		return trace.ParentBased(trace.AlwaysSample())
+	case "parentbased_always_off":
+		return trace.ParentBased(trace.NeverSample())
+	case "parentbased_traceidratio":
+		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
+	default: // empty/unknown → parent-based with configured ratio
+		return trace.ParentBased(trace.TraceIDRatioBased(cfg.TracesSampleRatio))
+	}
+}
+
 // newTraceProvider creates a TracerProvider with an OTLP exporter configured based on the protocol setting.
 func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resource) (*trace.TracerProvider, error) {
 	var exporter trace.SpanExporter
@@ -333,7 +370,7 @@ func newTraceProvider(ctx context.Context, cfg OTelConfig, res *resource.Resourc
 
 	traceProvider := trace.NewTracerProvider(
 		trace.WithResource(res),
-		trace.WithSampler(trace.TraceIDRatioBased(cfg.TracesSampleRatio)),
+		trace.WithSampler(newSampler(cfg)),
 		trace.WithBatcher(exporter,
 			trace.WithBatchTimeout(time.Second),
 		),

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -131,8 +131,8 @@ func OTelConfigFromEnv() OTelConfig {
 		propagators = "tracecontext,baggage"
 	}
 
-	tracesSampler := os.Getenv("OTEL_TRACES_SAMPLER")
-	tracesSamplerArg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+	tracesSampler := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER"))
+	tracesSamplerArg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
 
 	slog.With(
 		"service-name", serviceName,

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -318,8 +318,14 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
-				"provided-value", arg, "error", err)
+			// Log parse error or range validation failure
+			if err != nil {
+				slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
+					"provided-value", arg, "error", err)
+			} else {
+				slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], defaulting to 1.0",
+					"provided-value", arg)
+			}
 		}
 		return 1.0
 	}

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -76,6 +76,14 @@ type OTelConfig struct {
 	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
 	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
 	TracesSampleRatio float64
+	// TracesSampler specifies the traces sampler type.
+	// Supported values: "always_on", "always_off", "traceidratio",
+	// "parentbased_always_on", "parentbased_always_off", "parentbased_traceidratio"
+	// Env: OTEL_TRACES_SAMPLER (default: "")
+	TracesSampler string
+	// TracesSamplerArg specifies the argument for the sampler (e.g., ratio for traceidratio).
+	// Env: OTEL_TRACES_SAMPLER_ARG
+	TracesSamplerArg string
 	// MetricsExporter specifies the metrics exporter: "otlp" or "none".
 	// Env: OTEL_METRICS_EXPORTER (default: "none")
 	MetricsExporter string
@@ -142,6 +150,9 @@ func OTelConfigFromEnv() OTelConfig {
 		}
 	}
 
+	tracesSampler := os.Getenv("OTEL_TRACES_SAMPLER")
+	tracesSamplerArg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+
 	slog.With(
 		"service-name", serviceName,
 		"version", serviceVersion,
@@ -150,6 +161,8 @@ func OTelConfigFromEnv() OTelConfig {
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
 		"traces-sample-ratio", tracesSampleRatio,
+		"traces-sampler", tracesSampler,
+		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
 		"logs-exporter", logsExporter,
 		"propagators", propagators,
@@ -163,6 +176,8 @@ func OTelConfigFromEnv() OTelConfig {
 		Insecure:          insecure,
 		TracesExporter:    tracesExporter,
 		TracesSampleRatio: tracesSampleRatio,
+		TracesSampler:     tracesSampler,
+		TracesSamplerArg:  tracesSamplerArg,
 		MetricsExporter:   metricsExporter,
 		LogsExporter:      logsExporter,
 		Propagators:       propagators,
@@ -310,22 +325,28 @@ func endpointURL(raw string, insecure bool) string {
 	return "https://" + raw
 }
 
-// newSampler creates a trace.Sampler from OTEL_TRACES_SAMPLER and
-// OTEL_TRACES_SAMPLER_ARG environment variables, falling back to
-// parentbased_traceidratio with cfg.TracesSampleRatio when unset.
-// This ensures parent span sampling decisions are always honored.
+// newSampler creates a trace.Sampler from cfg.TracesSampler and
+// cfg.TracesSamplerArg, falling back to parentbased_traceidratio with
+// cfg.TracesSampleRatio when sampler is unset. This ensures parent span
+// sampling decisions are always honored when no explicit sampler is configured.
 func newSampler(cfg OTelConfig) trace.Sampler {
-	sampler := os.Getenv("OTEL_TRACES_SAMPLER")
-	arg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
+	sampler := cfg.TracesSampler
+	arg := cfg.TracesSamplerArg
 
 	parseRatio := func() float64 {
 		if arg != "" {
 			r, err := strconv.ParseFloat(arg, 64)
-			if err == nil && r >= 0.0 && r <= 1.0 {
-				return r
+			if err != nil {
+				slog.Warn("OTEL_TRACES_SAMPLER_ARG parse error, using TracesSampleRatio",
+					"value", arg, "sampler", sampler, "error", err)
+				return cfg.TracesSampleRatio
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
-				"value", arg, "sampler", sampler, "error", err)
+			if r < 0.0 || r > 1.0 {
+				slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], using TracesSampleRatio",
+					"value", arg, "sampler", sampler)
+				return cfg.TracesSampleRatio
+			}
+			return r
 		}
 		return cfg.TracesSampleRatio
 	}
@@ -343,7 +364,11 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 		return trace.ParentBased(trace.NeverSample())
 	case otelSamplerParentBasedTraceIDRatio:
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
-	default: // empty/unknown → parent-based with configured ratio
+	case "": // empty → parent-based with configured ratio (recommended default)
+		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
+	default: // unknown sampler type
+		slog.Warn("unknown OTEL_TRACES_SAMPLER value, defaulting to parentbased_traceidratio",
+			"value", sampler)
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	}
 }

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -72,10 +72,6 @@ type OTelConfig struct {
 	// TracesExporter specifies the traces exporter: "otlp" or "none".
 	// Env: OTEL_TRACES_EXPORTER (default: "none")
 	TracesExporter string
-	// TracesSampleRatio specifies the sampling ratio for traces (0.0 to 1.0).
-	// A value of 1.0 means all traces are sampled, 0.5 means 50% are sampled.
-	// Env: OTEL_TRACES_SAMPLE_RATIO (default: 1.0)
-	TracesSampleRatio float64
 	// TracesSampler specifies the traces sampler type.
 	// Supported values: "always_on", "always_off", "traceidratio",
 	// "parentbased_always_on", "parentbased_always_off", "parentbased_traceidratio"
@@ -135,21 +131,6 @@ func OTelConfigFromEnv() OTelConfig {
 		propagators = "tracecontext,baggage"
 	}
 
-	tracesSampleRatio := 1.0
-	if ratio := os.Getenv("OTEL_TRACES_SAMPLE_RATIO"); ratio != "" {
-		if parsed, err := strconv.ParseFloat(ratio, 64); err == nil {
-			if parsed >= 0.0 && parsed <= 1.0 {
-				tracesSampleRatio = parsed
-			} else {
-				slog.Warn("OTEL_TRACES_SAMPLE_RATIO must be between 0.0 and 1.0, using default 1.0",
-					"provided-value", ratio)
-			}
-		} else {
-			slog.Warn("invalid OTEL_TRACES_SAMPLE_RATIO value, using default 1.0",
-				"provided-value", ratio, "error", err)
-		}
-	}
-
 	tracesSampler := os.Getenv("OTEL_TRACES_SAMPLER")
 	tracesSamplerArg := os.Getenv("OTEL_TRACES_SAMPLER_ARG")
 
@@ -160,7 +141,6 @@ func OTelConfigFromEnv() OTelConfig {
 		"endpoint", endpoint,
 		"insecure", insecure,
 		"traces-exporter", tracesExporter,
-		"traces-sample-ratio", tracesSampleRatio,
 		"traces-sampler", tracesSampler,
 		"traces-sampler-arg", tracesSamplerArg,
 		"metrics-exporter", metricsExporter,
@@ -169,18 +149,17 @@ func OTelConfigFromEnv() OTelConfig {
 	).Debug("OTelConfig")
 
 	return OTelConfig{
-		ServiceName:       serviceName,
-		ServiceVersion:    serviceVersion,
-		Protocol:          protocol,
-		Endpoint:          endpoint,
-		Insecure:          insecure,
-		TracesExporter:    tracesExporter,
-		TracesSampleRatio: tracesSampleRatio,
-		TracesSampler:     tracesSampler,
-		TracesSamplerArg:  tracesSamplerArg,
-		MetricsExporter:   metricsExporter,
-		LogsExporter:      logsExporter,
-		Propagators:       propagators,
+		ServiceName:      serviceName,
+		ServiceVersion:   serviceVersion,
+		Protocol:         protocol,
+		Endpoint:         endpoint,
+		Insecure:         insecure,
+		TracesExporter:   tracesExporter,
+		TracesSampler:    tracesSampler,
+		TracesSamplerArg: tracesSamplerArg,
+		MetricsExporter:  metricsExporter,
+		LogsExporter:     logsExporter,
+		Propagators:      propagators,
 	}
 }
 
@@ -327,7 +306,7 @@ func endpointURL(raw string, insecure bool) string {
 
 // newSampler creates a trace.Sampler from cfg.TracesSampler and
 // cfg.TracesSamplerArg, falling back to parentbased_traceidratio with
-// cfg.TracesSampleRatio when sampler is unset. This ensures parent span
+// a default ratio of 1.0 when sampler is unset. This ensures parent span
 // sampling decisions are always honored when no explicit sampler is configured.
 func newSampler(cfg OTelConfig) trace.Sampler {
 	sampler := cfg.TracesSampler
@@ -336,19 +315,13 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 	parseRatio := func() float64 {
 		if arg != "" {
 			r, err := strconv.ParseFloat(arg, 64)
-			if err != nil {
-				slog.Warn("OTEL_TRACES_SAMPLER_ARG parse error, using TracesSampleRatio",
-					"value", arg, "sampler", sampler, "error", err)
-				return cfg.TracesSampleRatio
+			if err == nil && r >= 0.0 && r <= 1.0 {
+				return r
 			}
-			if r < 0.0 || r > 1.0 {
-				slog.Warn("OTEL_TRACES_SAMPLER_ARG out of range [0.0, 1.0], using TracesSampleRatio",
-					"value", arg, "sampler", sampler)
-				return cfg.TracesSampleRatio
-			}
-			return r
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, defaulting to 1.0",
+				"provided-value", arg, "error", err)
 		}
-		return cfg.TracesSampleRatio
+		return 1.0
 	}
 
 	switch sampler {

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -40,6 +40,14 @@ const (
 	OTelExporterOTLP = "otlp"
 	// OTelExporterNone disables exporting for a signal.
 	OTelExporterNone = "none"
+
+	// OTel sampler type constants for OTEL_TRACES_SAMPLER.
+	otelSamplerAlwaysOn                = "always_on"
+	otelSamplerAlwaysOff               = "always_off"
+	otelSamplerTraceIDRatio            = "traceidratio"
+	otelSamplerParentBasedAlwaysOn     = "parentbased_always_on"
+	otelSamplerParentBasedAlwaysOff    = "parentbased_always_off"
+	otelSamplerParentBasedTraceIDRatio = "parentbased_traceidratio"
 )
 
 // OTelConfig holds OpenTelemetry configuration options.
@@ -316,26 +324,27 @@ func newSampler(cfg OTelConfig) trace.Sampler {
 			if err == nil && r >= 0.0 && r <= 1.0 {
 				return r
 			}
-			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio", "value", arg)
+			slog.Warn("invalid OTEL_TRACES_SAMPLER_ARG, using TracesSampleRatio",
+				"value", arg, "sampler", sampler, "error", err)
 		}
 		return cfg.TracesSampleRatio
 	}
 
 	switch sampler {
-	case "always_on":
+	case otelSamplerAlwaysOn:
 		return trace.AlwaysSample()
-	case "always_off":
+	case otelSamplerAlwaysOff:
 		return trace.NeverSample()
-	case "traceidratio":
+	case otelSamplerTraceIDRatio:
 		return trace.TraceIDRatioBased(parseRatio())
-	case "parentbased_always_on":
+	case otelSamplerParentBasedAlwaysOn:
 		return trace.ParentBased(trace.AlwaysSample())
-	case "parentbased_always_off":
+	case otelSamplerParentBasedAlwaysOff:
 		return trace.ParentBased(trace.NeverSample())
-	case "parentbased_traceidratio":
+	case otelSamplerParentBasedTraceIDRatio:
 		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	default: // empty/unknown → parent-based with configured ratio
-		return trace.ParentBased(trace.TraceIDRatioBased(cfg.TracesSampleRatio))
+		return trace.ParentBased(trace.TraceIDRatioBased(parseRatio()))
 	}
 }
 

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -324,3 +324,49 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 
 	_ = shutdown(ctx)
 }
+
+// TestNewSampler verifies that newSampler returns a non-nil sampler for all
+// supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
+func TestNewSampler(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+
+	tests := []struct {
+		name    string
+		sampler string
+		arg     string
+	}{
+		{"default (empty)", "", ""},
+		{"always_on", "always_on", ""},
+		{"always_off", "always_off", ""},
+		{"traceidratio", "traceidratio", "0.5"},
+		{"parentbased_always_on", "parentbased_always_on", ""},
+		{"parentbased_always_off", "parentbased_always_off", ""},
+		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
+		{"unknown", "unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
+			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
+
+			s := newSampler(cfg)
+			if s == nil {
+				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+			}
+		})
+	}
+}
+
+// TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
+// falls back to cfg.TracesSampleRatio without panicking.
+func TestNewSampler_InvalidArg(t *testing.T) {
+	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
+
+	s := newSampler(cfg)
+	if s == nil {
+		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	}
+}

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -96,17 +96,34 @@ func TestOTelConfigFromEnv_UnsupportedProtocol(t *testing.T) {
 	}
 }
 
+// TestOTelConfigFromEnv_TraceSamplerEnvVars verifies that OTEL_TRACES_SAMPLER
+// and OTEL_TRACES_SAMPLER_ARG environment variables are correctly parsed and
+// stored in the OTelConfig, with leading/trailing whitespace trimmed.
+func TestOTelConfigFromEnv_TraceSamplerEnvVars(t *testing.T) {
+	t.Setenv("OTEL_TRACES_SAMPLER", "  parentbased_traceidratio  ")
+	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "  0.5  ")
+
+	cfg := OTelConfigFromEnv()
+
+	if cfg.TracesSampler != "parentbased_traceidratio" {
+		t.Errorf("expected TracesSampler 'parentbased_traceidratio' (trimmed), got %q", cfg.TracesSampler)
+	}
+	if cfg.TracesSamplerArg != "0.5" {
+		t.Errorf("expected TracesSamplerArg '0.5' (trimmed), got %q", cfg.TracesSamplerArg)
+	}
+}
+
 // TestSetupOTelSDKWithConfig_AllDisabled verifies that the SDK can be
 // initialized successfully when all exporters (traces, metrics, logs) are
 // disabled, and that the returned shutdown function works correctly.
 func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:    "test-service",
-		ServiceVersion: "1.0.0",
-		Protocol:       OTelProtocolGRPC,
-		TracesExporter: OTelExporterNone,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		TracesExporter:  OTelExporterNone,
 		MetricsExporter: OTelExporterNone,
-		LogsExporter:   OTelExporterNone,
+		LogsExporter:    OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -295,15 +312,15 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "127.0.0.1:4317")
 
 	cfg := OTelConfig{
-		ServiceName:    "test-service",
-		ServiceVersion: "1.0.0",
-		Protocol:       OTelProtocolGRPC,
-		Endpoint:       "127.0.0.1:4317",
-		Insecure:       true,
-		TracesExporter: OTelExporterOTLP,
+		ServiceName:     "test-service",
+		ServiceVersion:  "1.0.0",
+		Protocol:        OTelProtocolGRPC,
+		Endpoint:        "127.0.0.1:4317",
+		Insecure:        true,
+		TracesExporter:  OTelExporterOTLP,
 		MetricsExporter: OTelExporterNone,
-		LogsExporter:   OTelExporterNone,
-		Propagators:    "tracecontext,baggage",
+		LogsExporter:    OTelExporterNone,
+		Propagators:     "tracecontext,baggage",
 	}
 
 	ctx := context.Background()

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -453,6 +453,32 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 			if !strings.Contains(s.Description(), tt.desc) {
 				t.Errorf("expected Description containing %q, got %q", tt.desc, s.Description())
 			}
+
+			// Verify fallback behavior: invalid args should fall back to ratio 1.0
+			// For non-parent-based samplers, ratio 1.0 means always sample.
+			// For parent-based samplers, ratio 1.0 means honor parent (and sample if no parent).
+			if tt.samplerType == "traceidratio" {
+				// Non-parent-based: should always sample (ratio 1.0)
+				res := s.ShouldSample(trace.SamplingParameters{
+					ParentContext: context.Background(),
+					TraceID:       oteltrace.TraceID{9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9},
+					Name:          "fallback-check",
+				})
+				if res.Decision != trace.RecordAndSample {
+					t.Errorf("expected fallback ratio 1.0 to RecordAndSample, got %v", res.Decision)
+				}
+			} else if tt.samplerType == "parentbased_traceidratio" {
+				// Parent-based: should honor parent, and with no parent should sample (ratio 1.0 default)
+				res := s.ShouldSample(trace.SamplingParameters{
+					ParentContext: context.Background(),
+					TraceID:       oteltrace.TraceID{9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9},
+					Name:          "fallback-check",
+				})
+				// With no parent context and fallback ratio 1.0, should sample
+				if res.Decision != trace.RecordAndSample {
+					t.Errorf("expected parentbased fallback (ratio 1.0, no parent) to RecordAndSample, got %v", res.Decision)
+				}
+			}
 		})
 	}
 }

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -36,9 +36,6 @@ func TestOTelConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.TracesExporter != OTelExporterNone {
 		t.Errorf("expected default TracesExporter %q, got %q", OTelExporterNone, cfg.TracesExporter)
 	}
-	if cfg.TracesSampleRatio != 1.0 {
-		t.Errorf("expected default TracesSampleRatio 1.0, got %f", cfg.TracesSampleRatio)
-	}
 	if cfg.MetricsExporter != OTelExporterNone {
 		t.Errorf("expected default MetricsExporter %q, got %q", OTelExporterNone, cfg.MetricsExporter)
 	}
@@ -56,7 +53,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4318")
 	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
 	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
-	t.Setenv("OTEL_TRACES_SAMPLE_RATIO", "0.5")
 	t.Setenv("OTEL_METRICS_EXPORTER", "otlp")
 	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
 
@@ -79,9 +75,6 @@ func TestOTelConfigFromEnv_CustomValues(t *testing.T) {
 	}
 	if cfg.TracesExporter != OTelExporterOTLP {
 		t.Errorf("expected TracesExporter %q, got %q", OTelExporterOTLP, cfg.TracesExporter)
-	}
-	if cfg.TracesSampleRatio != 0.5 {
-		t.Errorf("expected TracesSampleRatio 0.5, got %f", cfg.TracesSampleRatio)
 	}
 	if cfg.MetricsExporter != OTelExporterOTLP {
 		t.Errorf("expected MetricsExporter %q, got %q", OTelExporterOTLP, cfg.MetricsExporter)
@@ -108,13 +101,12 @@ func TestOTelConfigFromEnv_UnsupportedProtocol(t *testing.T) {
 // disabled, and that the returned shutdown function works correctly.
 func TestSetupOTelSDKWithConfig_AllDisabled(t *testing.T) {
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		TracesExporter:    OTelExporterNone,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Protocol:       OTelProtocolGRPC,
+		TracesExporter: OTelExporterNone,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:   OTelExporterNone,
 	}
 
 	ctx := context.Background()
@@ -303,16 +295,15 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "127.0.0.1:4317")
 
 	cfg := OTelConfig{
-		ServiceName:       "test-service",
-		ServiceVersion:    "1.0.0",
-		Protocol:          OTelProtocolGRPC,
-		Endpoint:          "127.0.0.1:4317",
-		Insecure:          true,
-		TracesExporter:    OTelExporterOTLP,
-		TracesSampleRatio: 1.0,
-		MetricsExporter:   OTelExporterNone,
-		LogsExporter:      OTelExporterNone,
-		Propagators:       "tracecontext,baggage",
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Protocol:       OTelProtocolGRPC,
+		Endpoint:       "127.0.0.1:4317",
+		Insecure:       true,
+		TracesExporter: OTelExporterOTLP,
+		MetricsExporter: OTelExporterNone,
+		LogsExporter:   OTelExporterNone,
+		Propagators:    "tracecontext,baggage",
 	}
 
 	ctx := context.Background()
@@ -332,7 +323,7 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 // supported OTEL_TRACES_SAMPLER values and validates their behavior via Description()
 // and parent span context awareness.
 func TestNewSampler(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
+	cfg := OTelConfig{}
 
 	tests := []struct {
 		name            string
@@ -421,7 +412,7 @@ func isParentBasedSampler(t *testing.T, sampler trace.Sampler) bool {
 }
 
 // TestNewSampler_InvalidArg verifies that invalid OTEL_TRACES_SAMPLER_ARG
-// values (parse errors and out-of-range) fall back to cfg.TracesSampleRatio.
+// values (parse errors and out-of-range) fall back to default ratio of 1.0.
 func TestNewSampler_InvalidArg(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -436,7 +427,7 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := OTelConfig{TracesSampleRatio: 0.5, TracesSampler: tt.samplerType, TracesSamplerArg: tt.samplerArg}
+			cfg := OTelConfig{TracesSampler: tt.samplerType, TracesSamplerArg: tt.samplerArg}
 			s := newSampler(cfg)
 			if s == nil {
 				t.Error("newSampler returned nil for invalid arg")

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -337,8 +336,8 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 }
 
 // TestNewSampler verifies that newSampler creates correct samplers for all
-// supported OTEL_TRACES_SAMPLER values and validates their behavior via Description()
-// and parent span context awareness.
+// supported OTEL_TRACES_SAMPLER values and validates their behavior via
+// ShouldSample decisions and parent span context awareness.
 func TestNewSampler(t *testing.T) {
 	cfg := OTelConfig{}
 
@@ -346,17 +345,17 @@ func TestNewSampler(t *testing.T) {
 		name            string
 		samplerType     string
 		samplerArg      string
-		wantDescription string // substring match for Description()
-		wantParentBased bool   // whether sampler should respect parent sampling
+		wantParentBased bool // whether sampler should respect parent sampling
+		wantNeverSample bool // whether sampler should always drop (always_off)
 	}{
-		{"default (empty)", "", "", "ParentBased", true},
-		{"always_on", "always_on", "", "AlwaysOnSampler", false},
-		{"always_off", "always_off", "", "AlwaysOffSampler", false},
-		{"traceidratio", "traceidratio", "0.5", "TraceIDRatioBased", false},
-		{"parentbased_always_on", "parentbased_always_on", "", "ParentBased", true},
-		{"parentbased_always_off", "parentbased_always_off", "", "ParentBased", true},
-		{"parentbased_traceidratio", "parentbased_traceidratio", "0.3", "ParentBased", true},
-		{"unknown (defaults to parentbased)", "unknown_sampler", "", "ParentBased", true},
+		{"default (empty)", "", "", true, false},
+		{"always_on", "always_on", "", false, false},
+		{"always_off", "always_off", "", false, true},
+		{"traceidratio", "traceidratio", "1.0", false, false},
+		{"parentbased_always_on", "parentbased_always_on", "", true, false},
+		{"parentbased_always_off", "parentbased_always_off", "", true, false},
+		{"parentbased_traceidratio", "parentbased_traceidratio", "0.3", true, false},
+		{"unknown (defaults to parentbased)", "unknown_sampler", "", true, false},
 	}
 
 	for _, tt := range tests {
@@ -370,16 +369,30 @@ func TestNewSampler(t *testing.T) {
 				return
 			}
 
-			desc := s.Description()
-			if !strings.Contains(desc, tt.wantDescription) {
-				t.Errorf("sampler Description() = %q, want substring %q", desc, tt.wantDescription)
-			}
-
-			// Validate parent-based behavior: parent-based samplers should honor
-			// the parent's sampling decision when a remote parent is present.
 			if tt.wantParentBased {
+				// Validate parent-based behavior: sampler should honor the
+				// parent's sampling decision when a remote parent is present.
 				if !isParentBasedSampler(t, s) {
 					t.Errorf("sampler %q should respect parent span context but doesn't", tt.name)
+				}
+			} else if tt.wantNeverSample {
+				res := s.ShouldSample(trace.SamplingParameters{
+					ParentContext: context.Background(),
+					TraceID:       oteltrace.TraceID{1},
+					Name:          "test",
+				})
+				if res.Decision != trace.Drop {
+					t.Errorf("sampler %q: expected Drop, got %v", tt.name, res.Decision)
+				}
+			} else {
+				// Non-parent-based, always-sample (ratio 1.0): should record.
+				res := s.ShouldSample(trace.SamplingParameters{
+					ParentContext: context.Background(),
+					TraceID:       oteltrace.TraceID{1},
+					Name:          "test",
+				})
+				if res.Decision != trace.RecordAndSample {
+					t.Errorf("sampler %q: expected RecordAndSample, got %v", tt.name, res.Decision)
 				}
 			}
 		})
@@ -435,11 +448,10 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 		name        string
 		samplerType string
 		samplerArg  string
-		desc        string
 	}{
-		{"non-numeric arg", "parentbased_traceidratio", "invalid", "ParentBased"},
-		{"out of range (>1.0)", "parentbased_traceidratio", "1.5", "ParentBased"},
-		{"out of range (<0.0)", "traceidratio", "-0.1", "TraceIDRatioBased"},
+		{"non-numeric arg", "parentbased_traceidratio", "invalid"},
+		{"out of range (>1.0)", "parentbased_traceidratio", "1.5"},
+		{"out of range (<0.0)", "traceidratio", "-0.1"},
 	}
 
 	for _, tt := range tests {
@@ -449,9 +461,6 @@ func TestNewSampler_InvalidArg(t *testing.T) {
 			if s == nil {
 				t.Error("newSampler returned nil for invalid arg")
 				return
-			}
-			if !strings.Contains(s.Description(), tt.desc) {
-				t.Errorf("expected Description containing %q, got %q", tt.desc, s.Description())
 			}
 
 			// Verify fallback behavior: invalid args should fall back to ratio 1.0

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -8,6 +8,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // TestOTelConfigFromEnv_Defaults verifies that OTelConfigFromEnv returns
@@ -326,7 +329,8 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 }
 
 // TestNewSampler verifies that newSampler creates correct samplers for all
-// supported OTEL_TRACES_SAMPLER values and validates their behavior via Description().
+// supported OTEL_TRACES_SAMPLER values and validates their behavior via Description()
+// and parent span context awareness.
 func TestNewSampler(t *testing.T) {
 	cfg := OTelConfig{TracesSampleRatio: 0.5}
 
@@ -362,8 +366,58 @@ func TestNewSampler(t *testing.T) {
 			if !strings.Contains(desc, tt.wantDescription) {
 				t.Errorf("sampler Description() = %q, want substring %q", desc, tt.wantDescription)
 			}
+
+			// Validate parent-based behavior: parent-based samplers should honor
+			// the parent's sampling decision when a remote parent is present.
+			if tt.wantParentBased {
+				if !isParentBasedSampler(t, s) {
+					t.Errorf("sampler %q should respect parent span context but doesn't", tt.name)
+				}
+			}
 		})
 	}
+}
+
+// isParentBasedSampler checks if a sampler respects parent sampling decisions
+// by testing with a sampled and non-sampled parent context.
+func isParentBasedSampler(t *testing.T, sampler trace.Sampler) bool {
+	// Create span contexts with sampled and non-sampled flags
+	sampledCtx := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    oteltrace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		SpanID:     oteltrace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+		TraceFlags: oteltrace.TraceFlags(1), // sampled (0x01)
+		Remote:     true,
+	})
+
+	nonSampledCtx := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    oteltrace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		SpanID:     oteltrace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+		TraceFlags: oteltrace.TraceFlags(0), // not sampled (0x00)
+		Remote:     true,
+	})
+
+	sampledParent := oteltrace.ContextWithSpanContext(context.Background(), sampledCtx)
+	nonSampledParent := oteltrace.ContextWithSpanContext(context.Background(), nonSampledCtx)
+
+	// For parent-based samplers:
+	// - When parent is sampled, decision should be RECORD_AND_SAMPLE
+	// - When parent is not sampled, decision should be DROP
+	// For non-parent-based samplers, both should make independent decisions.
+
+	sampledResult := sampler.ShouldSample(trace.SamplingParameters{
+		ParentContext: sampledParent,
+		TraceID:       sampledCtx.TraceID(),
+		Name:          "test",
+	})
+	nonSampledResult := sampler.ShouldSample(trace.SamplingParameters{
+		ParentContext: nonSampledParent,
+		TraceID:       nonSampledCtx.TraceID(),
+		Name:          "test",
+	})
+
+	// Parent-based samplers honor parent: sampled parent → sampled span, non-sampled → dropped
+	// Non-parent-based samplers may make independent decisions regardless of parent
+	return sampledResult.Decision == trace.RecordAndSample && nonSampledResult.Decision == trace.Drop
 }
 
 // TestNewSampler_InvalidArg verifies that invalid OTEL_TRACES_SAMPLER_ARG

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -6,7 +6,7 @@ package utils
 
 import (
 	"context"
-
+	"strings"
 	"testing"
 )
 
@@ -325,48 +325,72 @@ func TestSetupOTelSDKWithConfig_IPEndpoint(t *testing.T) {
 	_ = shutdown(ctx)
 }
 
-// TestNewSampler verifies that newSampler returns a non-nil sampler for all
-// supported OTEL_TRACES_SAMPLER values, including the default (empty) case.
+// TestNewSampler verifies that newSampler creates correct samplers for all
+// supported OTEL_TRACES_SAMPLER values and validates their behavior via Description().
 func TestNewSampler(t *testing.T) {
 	cfg := OTelConfig{TracesSampleRatio: 0.5}
 
 	tests := []struct {
-		name    string
-		sampler string
-		arg     string
+		name              string
+		samplerType       string
+		samplerArg        string
+		wantDescription   string // substring match for Description()
+		wantParentBased   bool   // whether sampler should respect parent sampling
 	}{
-		{"default (empty)", "", ""},
-		{"always_on", "always_on", ""},
-		{"always_off", "always_off", ""},
-		{"traceidratio", "traceidratio", "0.5"},
-		{"parentbased_always_on", "parentbased_always_on", ""},
-		{"parentbased_always_off", "parentbased_always_off", ""},
-		{"parentbased_traceidratio", "parentbased_traceidratio", "0.5"},
-		{"unknown", "unknown", ""},
+		{"default (empty)", "", "", "ParentBased", true},
+		{"always_on", "always_on", "", "AlwaysOnSampler", false},
+		{"always_off", "always_off", "", "AlwaysOffSampler", false},
+		{"traceidratio", "traceidratio", "0.5", "TraceIDRatioBased", false},
+		{"parentbased_always_on", "parentbased_always_on", "", "ParentBased", true},
+		{"parentbased_always_off", "parentbased_always_off", "", "ParentBased", true},
+		{"parentbased_traceidratio", "parentbased_traceidratio", "0.3", "ParentBased", true},
+		{"unknown (defaults to parentbased)", "unknown_sampler", "", "ParentBased", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OTEL_TRACES_SAMPLER", tt.sampler)
-			t.Setenv("OTEL_TRACES_SAMPLER_ARG", tt.arg)
+			cfg.TracesSampler = tt.samplerType
+			cfg.TracesSamplerArg = tt.samplerArg
 
 			s := newSampler(cfg)
 			if s == nil {
-				t.Errorf("newSampler(%q) returned nil", tt.sampler)
+				t.Errorf("newSampler returned nil for %q", tt.samplerType)
+				return
+			}
+
+			desc := s.Description()
+			if !strings.Contains(desc, tt.wantDescription) {
+				t.Errorf("sampler Description() = %q, want substring %q", desc, tt.wantDescription)
 			}
 		})
 	}
 }
 
-// TestNewSampler_InvalidArg verifies that an invalid OTEL_TRACES_SAMPLER_ARG
-// falls back to cfg.TracesSampleRatio without panicking.
+// TestNewSampler_InvalidArg verifies that invalid OTEL_TRACES_SAMPLER_ARG
+// values (parse errors and out-of-range) fall back to cfg.TracesSampleRatio.
 func TestNewSampler_InvalidArg(t *testing.T) {
-	cfg := OTelConfig{TracesSampleRatio: 0.5}
-	t.Setenv("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
-	t.Setenv("OTEL_TRACES_SAMPLER_ARG", "invalid")
+	tests := []struct {
+		name        string
+		samplerType string
+		samplerArg  string
+		desc        string
+	}{
+		{"non-numeric arg", "parentbased_traceidratio", "invalid", "ParentBased"},
+		{"out of range (>1.0)", "parentbased_traceidratio", "1.5", "ParentBased"},
+		{"out of range (<0.0)", "traceidratio", "-0.1", "TraceIDRatioBased"},
+	}
 
-	s := newSampler(cfg)
-	if s == nil {
-		t.Error("newSampler returned nil for invalid OTEL_TRACES_SAMPLER_ARG")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := OTelConfig{TracesSampleRatio: 0.5, TracesSampler: tt.samplerType, TracesSamplerArg: tt.samplerArg}
+			s := newSampler(cfg)
+			if s == nil {
+				t.Error("newSampler returned nil for invalid arg")
+				return
+			}
+			if !strings.Contains(s.Description(), tt.desc) {
+				t.Errorf("expected Description containing %q, got %q", tt.desc, s.Description())
+			}
+		})
 	}
 }

--- a/pkg/utils/otel_test.go
+++ b/pkg/utils/otel_test.go
@@ -331,11 +331,11 @@ func TestNewSampler(t *testing.T) {
 	cfg := OTelConfig{TracesSampleRatio: 0.5}
 
 	tests := []struct {
-		name              string
-		samplerType       string
-		samplerArg        string
-		wantDescription   string // substring match for Description()
-		wantParentBased   bool   // whether sampler should respect parent sampling
+		name            string
+		samplerType     string
+		samplerArg      string
+		wantDescription string // substring match for Description()
+		wantParentBased bool   // whether sampler should respect parent sampling
 	}{
 		{"default (empty)", "", "", "ParentBased", true},
 		{"always_on", "always_on", "", "AlwaysOnSampler", false},


### PR DESCRIPTION
## Summary

Fixes LFXV2-1734 — all Go service spans have \`parentid: 0\` in Datadog because \`TraceIDRatioBased\` makes independent sampling decisions, ignoring incoming \`traceparent\` headers.

## Changes

**\`pkg/utils/otel.go\`** — Replace bare \`trace.TraceIDRatioBased(ratio)\` with a new \`newSampler(cfg)\` function that:
- Reads \`OTEL_TRACES_SAMPLER\` / \`OTEL_TRACES_SAMPLER_ARG\` (standard OTel env vars)
- Defaults to \`parentbased_traceidratio\` with ratio \`1.0\` when unset
- Supports all 6 OTel sampler types: \`always_on\`, \`always_off\`, \`traceidratio\`, \`parentbased_always_on\`, \`parentbased_always_off\`, \`parentbased_traceidratio\`
- Removes \`TracesSampleRatio\` / \`OTEL_TRACES_SAMPLE_RATIO\` entirely — no backward compatibility fallback; configure sampling via \`OTEL_TRACES_SAMPLER_ARG\`

**\`pkg/utils/otel_test.go\`** — Added \`TestNewSampler\`, \`TestNewSampler_InvalidArg\`, and \`TestNewSampler_ParentHonored\`

**\`charts/lfx-v2-fga-sync/templates/deployment.yaml\`** — Renders \`OTEL_TRACES_SAMPLER\` when \`application.otel.tracesSampler\` is non-empty; renders \`OTEL_TRACES_SAMPLER_ARG\` when \`application.otel.tracesSamplerArg\` is non-empty (independent conditions)

**\`charts/lfx-v2-fga-sync/values.yaml\`** — Added \`tracesSampler: ""\` and \`tracesSamplerArg: ""\` to \`application.otel\`

## Why

\`TraceIDRatioBased\` re-decides sampling per span regardless of the parent's sampling flag. Wrapping with \`parentbased_traceidratio\` ensures child spans always follow the parent's decision, restoring end-to-end trace continuity.

\`OTEL_TRACES_SAMPLER_ARG\` replaces the old \`OTEL_TRACES_SAMPLE_RATIO\` / \`TracesSampleRatio\` mechanism. All deployments have been updated in ArgoCD values to use \`tracesSamplerArg\` directly. No backward compatibility fallback is provided.

Issue: LFXV2-1734