### PR TITLE
docs: LFXV2-1365 — add lfx-v2-member-service to FGA catalog

### DIFF
--- a/docs/fga-catalog.md
+++ b/docs/fga-catalog.md
@@ -21,6 +21,7 @@ match the type prefixes defined in `pkg/constants/fga.go` (without the trailing 
 | [lfx-v2-voting-service](https://github.com/linuxfoundation/lfx-v2-voting-service) | `vote`, `vote_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-voting-service/blob/main/docs/fga-contract.md) |
 | [lfx-v2-survey-service](https://github.com/linuxfoundation/lfx-v2-survey-service) | `survey`, `survey_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-survey-service/blob/main/docs/fga-contract.md) |
 | [lfx-v2-mailing-list-service](https://github.com/linuxfoundation/lfx-v2-mailing-list-service) | `groupsio_service`, `groupsio_mailing_list` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/blob/main/docs/fga-contract.md) |
+| [lfx-v2-member-service](https://github.com/linuxfoundation/lfx-v2-member-service) | `b2b_org`, `project_membership` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-member-service/blob/main/docs/fga-contract.md) |
 
 ---
 

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -48,6 +48,8 @@ const (
 	ObjectTypePastMeetingSummary    = "past_meeting_summary:"
 	ObjectTypeGroupsIOService       = "groupsio_service:"
 	ObjectTypeGroupsIOMailingList   = "groupsio_mailing_list:"
+	ObjectTypeB2BOrg                = "b2b_org:"
+	ObjectTypeProjectMembership     = "project_membership:"
 
 	// V1 object type prefixes (for read-only LFX v1 data sync)
 	ObjectTypeV1Meeting               = "v1_meeting:"


### PR DESCRIPTION
## Summary

- Adds member service row to the FGA contract catalog
- Object types: `b2b_org` (update_access / delete_access + reparenting child/parent tuples) and `project_membership` (member_put / member_remove for the `key_contact` relation)
- Links to the new [`docs/fga-contract.md`](https://github.com/linuxfoundation/lfx-v2-member-service/blob/main/docs/fga-contract.md) in lfx-v2-member-service

Companion PR: https://github.com/linuxfoundation/lfx-v2-member-service/pull/41

Jira: LFXV2-1365
Link: https://linuxfoundation.atlassian.net/browse/LFXV2-1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)