### PR TITLE
docs: repo-owned FGA contract and tuple-emission guidance (LFXV2-2015)

### DIFF
--- a/.claude/skills/fga-sync-dev/SKILL.md
+++ b/.claude/skills/fga-sync-dev/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: fga-sync-dev
+description: Path-scoped Go coding conventions for the lfx-v2-fga-sync repository. Owns repo-local truth for the single-package main layout, slog logging style, NATS QueueSubscribe + JetStream KV cache patterns, the generic resource-agnostic handler shape, table-driven tests against the INatsMsg/FgaService mocks, license headers, and Makefile-driven lint/format/build. Auto-attaches on Go files, go.mod/go.sum, Makefile, charts, scripts, and pkg. Defers cross-repo platform topology to lfx-skills:lfx-platform-architecture, the FGA tuple-emission contract to docs/fga-sync-contract.md, and the publisher-side workflow to the peer fga-tuple-emission skill.
+paths:
+  - "**/*.go"
+  - "go.mod"
+  - "go.sum"
+  - "Makefile"
+  - "pkg/**"
+  - "charts/**"
+  - "scripts/**"
+  - ".claude/skills/fga-sync-dev/**"
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+# Development Conventions (lfx-v2-fga-sync)
+
+Repo-local Go conventions for fga-sync. This service is a single Go `package main` at the repo root, not the multi-module Goa layout most V2 repos use. Conventions encode that shape plus the fga-sync-specific NATS, cache, and handler patterns.
+
+## Boundaries
+
+- Platform topology, V2 service classification, write/read/access-check flows across repos, and OpenFGA model coordination order live in `lfx-skills:lfx-platform-architecture`. Read it before tracing cross-repo work.
+- The `GenericFGAMessage` envelope, generic subjects, tuple format, cache invalidation protocol, model boundaries, and the two-step access-debug tree live in `docs/fga-sync-contract.md`. That doc is the contract other repos read. Update it in the same PR as any envelope or subject change.
+- The peer `fga-tuple-emission` skill (do not edit from here) owns the publisher-side workflow for resource services that emit tuples.
+- This skill owns how fga-sync's own Go code is structured and how its handlers, cache, and subscriptions are wired.
+
+## Repo layout
+
+| Area | Where |
+| --- | --- |
+| Entry point, NATS wiring, HTTP probes, graceful shutdown | `main.go` |
+| Shared `HandlerService`, `INatsMsg`, response stubs | `handler.go` |
+| Per-subject handlers | `handler_access.go`, `handler_read_tuples.go`, `handler_generic.go` |
+| `FgaService` and OpenFGA tuple I/O | `fga.go`, `fga_client.go` |
+| Test mocks for NATS, OpenFGA, KV | `mock.go` |
+| Constants (relations, object types, subjects, queue, KV bucket) | `pkg/constants/` |
+| Typed payloads | `pkg/types/` |
+| Shared helpers | `pkg/utils/` |
+| Helm chart | `charts/lfx-v2-fga-sync/` |
+| Domain and contract docs | `docs/` |
+
+There is no `cmd/`, `internal/`, `api/`, or `gen/` tree. Do not introduce a Goa design here; this service is NATS-only on the inbound side and OpenFGA-SDK on the outbound side.
+
+## Go conventions
+
+### Package and imports
+
+- Everything implementation-level is `package main`. Add new files to the root unless they are pure helpers, constants, or typed payloads that belong under `pkg/`.
+- Group imports in three blocks: standard library, third-party, then `github.com/linuxfoundation/lfx-v2-fga-sync/...`. Run `make fmt` to enforce.
+- Match the existing constructor style on `HandlerService` and `FgaService`. Both are passed by value or by small struct; do not introduce pointer receivers without a reason.
+
+### Logging
+
+- Use the package-level `logger` (a `*slog.Logger` wrapped by `slog-otel`). Do not call `fmt.Println`, `fmt.Printf`, `log.Print*`, or `log.Println` for runtime logging.
+- Use `*Context` variants (`InfoContext`, `WarnContext`, `DebugContext`, `ErrorContext`) so trace and span IDs flow through. Pass the same `ctx` you handed to `FgaService` calls.
+- Use the package-level `errKey = "error"` constant for error fields; do not invent new keys for the same concept.
+- Include stable structured fields when available: `subject`, `queue`, `object_type`, `object_id`, `relation`, `principal`, `operation`, `count`.
+- Never log raw payloads, bearer tokens, or anything that may contain PII. Logging `string(message.Data())` at info level is acceptable for the existing access-check and read-tuples flows because those payloads are tuple-shaped, not user content; do not extend that pattern to new payload types without checking.
+- Honor `DEBUG` and the `-d` flag for debug logging; both already wire into `logOptions.Level`.
+
+### Error handling
+
+- Return errors from handlers; `subscribeToSubject` logs them with `subject` and `queue` context. Do not log-and-swallow inside handlers unless you also send the subject's documented failure reply.
+- Reply contract by subject (see also `references/nats-messaging.md`):
+  - `lfx.access_check.request`: tab-separated `{object}#{relation}@user:{principal}\t{true|false}` per line. Absent line means denied.
+  - `lfx.access_check.read_tuples`: JSON `{"results": [...]}` on success, `{"error": "..."}` on failure.
+  - `lfx.fga-sync.*`: `OK` on success only when `message.Reply() != ""`; failures are returned to the subscription loop for logging and do not have a standardized NATS error body.
+- Wrap upstream OpenFGA or NATS errors with `fmt.Errorf("...: %w", err)` so `errors.Is`/`errors.Unwrap` keep working.
+- Graceful degradation on cache miss is intentional: fall through to a direct OpenFGA query rather than failing the request.
+- The service must keep running on individual message failures. Never call `os.Exit` from a handler.
+
+### Handlers (generic, resource-agnostic)
+
+- All sync handlers (`genericUpdateAccessHandler`, `genericDeleteAccessHandler`, `genericMemberPutHandler`, `genericMemberRemoveHandler`) operate on `GenericFGAMessage`. They must stay object-type-agnostic. New resource types must NOT require a new handler.
+- If a new resource type seems to need handler changes, the envelope is drifting. Push the change into `GenericFGAMessage` fields or into the model in `lfx-v2-helm`, not into fga-sync.
+- `FgaService` should stay generic: tuple read, write, delete, sync. Domain knowledge about projects, meetings, committees, etc. stays out of `FgaService`.
+- `buildObjectID(objectType, uid)` in `handler.go` is the single helper for `"type:uid"` formatting. Do not concat inline.
+- Use `pkg/constants` for relation names, object-type prefixes, subjects, and the queue group. Do not hardcode subject strings, queue strings, or relation literals at call sites.
+
+### NATS subscriptions
+
+- All subscriptions are added to the slice in `createQueueSubscriptions` in `main.go`. Adding a new subject means adding a `subscriptionConfig` entry and a `HandlerFunc`; the helper handles error logging.
+- Queue group for every subscription is `constants.FgaSyncQueue` (value `"lfx.fga-sync.queue"`) so only one replica handles each message when scaled.
+- `INatsMsg` is the interface used in handler signatures; tests use the `mock.go` fake. Do not take `*nats.Msg` directly in handler signatures, or unit tests will not be able to drive them.
+- Drain the NATS connection during graceful shutdown via the existing path in `main.go`. `gracefulShutdownSeconds` (25s) must stay higher than the NATS client request timeout and lower than the pod's `terminationGracePeriodSeconds`.
+
+### JetStream KV cache
+
+- Cache bucket name comes from `CACHE_BUCKET` (default `fga-sync-cache`). Do not hardcode the bucket name; use `constants.KVBucketNameSyncCache` or the resolved `cacheBucketName`.
+- Cache keys are `rel.{base32-encoded-relation}`. Values are raw text booleans (`true` or `false`); freshness comes from the NATS KV entry timestamp. Do not change either shape without coordinating with consumers and updating `docs/fga-sync-contract.md`.
+- Invalidation is a single `inv` timestamp key. Every successful OpenFGA write must bump it (`invalidateCache`); any cached entry older than `inv` is treated as stale.
+- Stale hits are counted separately at `/debug/vars` (`cache_stale_hits`); do not collapse them into `cache_hits`.
+- Local development against an externally written OpenFGA store should run with `USE_CACHE=false` to avoid serving stale results.
+
+### Tests
+
+- Co-locate `*_test.go` with the file under test (`handler_access_test.go` next to `handler_access.go`, etc.).
+- Use the `INatsMsg` interface and the mocks in `mock.go` to drive handlers; do not stand up a real NATS connection in unit tests.
+- Depend on the `FgaService` surface; do not call the OpenFGA SDK directly from handler tests.
+- Use table-driven tests for branching behavior. One test function per exported (or top-level) handler, with cases added to the table.
+- Run `make test` (or `make test-coverage` for an HTML report) before handing off. There is no in-repo integration suite; integration coverage lives in the platform stack via `lfx-v2-helm` and `load-mock-data`.
+
+### Formatting, lint, license
+
+- Run `make fmt` and `make lint` (golangci-lint) on every Go change. `make check` runs format, vet, and lint together; prefer it before handing off.
+- Every new Go file starts with:
+
+  ```go
+  // Copyright The Linux Foundation and each contributor to LFX.
+  // SPDX-License-Identifier: MIT
+  ```
+
+- Document exported Go symbols when the linter requires it; otherwise add comments only where the code is not self-explanatory.
+- Update `docs/fga-sync-contract.md` in the same PR as any change to subjects, envelopes, reply shapes, cache keys, or invalidation behavior. That doc is read by other repos.
+
+## Cross-repo coordination
+
+OpenFGA model changes touch multiple repos and must ship in coordinated PRs. See the OpenFGA + Heimdall coordination section in `lfx-skills:lfx-platform-architecture` for the canonical order (model in `lfx-v2-helm`, emitted envelope in the owning service, Heimdall ruleset in the owning service's chart, local FGA contract docs, then `lfx-v2-argocd` rollout). fga-sync itself should not need code changes for a new resource type.
+
+## References
+
+- `references/nats-messaging.md`: fga-sync's exact subscriptions, queue group name, and per-subject reply shapes. Read when wiring a new subject or auditing reply behavior.
+- `references/go-development-conventions.md`: longer-form Go conventions shared across V2 services (logging, errors, request context, pagination, tests, formatting). Read when onboarding to V2 Go style; the inline body above is the fga-sync-specific overlay.

--- a/.claude/skills/fga-sync-dev/SKILL.md
+++ b/.claude/skills/fga-sync-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fga-sync-dev
-description: Path-scoped Go coding conventions for the lfx-v2-fga-sync repository. Owns repo-local truth for the single-package main layout, slog logging style, NATS QueueSubscribe + JetStream KV cache patterns, the generic resource-agnostic handler shape, table-driven tests against the INatsMsg/FgaService mocks, license headers, and Makefile-driven lint/format/build. Auto-attaches on Go files, go.mod/go.sum, Makefile, charts, scripts, and pkg. Defers cross-repo platform topology to lfx-skills:lfx-platform-architecture, the FGA tuple-emission contract to docs/fga-sync-contract.md, and the publisher-side workflow to the peer fga-tuple-emission skill.
+description: Path-scoped Go coding conventions for the lfx-v2-fga-sync repository. Owns repo-local truth for the single-package main layout, slog logging style, NATS QueueSubscribe + JetStream KV cache patterns, the generic resource-agnostic handler shape, table-driven tests against the INatsMsg/IFgaClient mocks, license headers, and Makefile-driven lint/format/build. Auto-attaches on Go files, go.mod/go.sum, Makefile, charts, scripts, and pkg. Defers cross-repo platform topology to lfx-skills:lfx-platform-architecture, the FGA tuple-emission contract to docs/fga-sync-contract.md, and the publisher-side workflow to the peer fga-tuple-emission skill.
 paths:
   - "**/*.go"
   - "go.mod"
@@ -47,15 +47,15 @@ There is no `cmd/`, `internal/`, `api/`, or `gen/` tree. Do not introduce a Goa 
 
 - Everything implementation-level is `package main`. Add new files to the root unless they are pure helpers, constants, or typed payloads that belong under `pkg/`.
 - Group imports in three blocks: standard library, third-party, then `github.com/linuxfoundation/lfx-v2-fga-sync/...`. Run `make fmt` to enforce.
-- Match the existing constructor style on `HandlerService` and `FgaService`. Both are passed by value or by small struct; do not introduce pointer receivers without a reason.
+- Match the existing receiver style: `HandlerService` handler methods use pointer receivers (`func (h *HandlerService)`); `FgaService` methods use value receivers (`func (s FgaService)`). Both are constructed as small struct values in `main.go`; do not switch receiver styles without a reason.
 
 ### Logging
 
 - Use the package-level `logger` (a `*slog.Logger` wrapped by `slog-otel`). Do not call `fmt.Println`, `fmt.Printf`, `log.Print*`, or `log.Println` for runtime logging.
 - Use `*Context` variants (`InfoContext`, `WarnContext`, `DebugContext`, `ErrorContext`) so trace and span IDs flow through. Pass the same `ctx` you handed to `FgaService` calls.
 - Use the package-level `errKey = "error"` constant for error fields; do not invent new keys for the same concept.
-- Include stable structured fields when available: `subject`, `queue`, `object_type`, `object_id`, `relation`, `principal`, `operation`, `count`.
-- Never log raw payloads, bearer tokens, or anything that may contain PII. Logging `string(message.Data())` at info level is acceptable for the existing access-check and read-tuples flows because those payloads are tuple-shaped, not user content; do not extend that pattern to new payload types without checking.
+- Include stable structured fields when available, matching the names already used in the code: `subject`, `queue`, `object_type`, `uid`, `object`, `user`, `username`, `relation`/`relations`, `operation`, `count`.
+- Never log raw payloads, bearer tokens, or anything that may contain PII. Logging `string(message.Data())` at info level is acceptable for the existing access-check and sync update-access flows because those payloads are tuple-shaped, not user content (read-tuples logs only parsed fields); do not extend that pattern to new payload types without checking.
 - Honor `DEBUG` and the `-d` flag for debug logging; both already wire into `logOptions.Level`.
 
 ### Error handling

--- a/.claude/skills/fga-sync-dev/references/go-development-conventions.md
+++ b/.claude/skills/fga-sync-dev/references/go-development-conventions.md
@@ -1,0 +1,49 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Go Development Conventions (V2 baseline)
+
+Longer-form Go style conventions shared across LFX V2 Go services. The inline body of `SKILL.md` is the fga-sync-specific overlay (single `package main`, slog wrapper, `INatsMsg` mocks, JetStream KV cache pattern). This reference covers shared patterns that are not repeated there: idiomatic Go style, error mapping, context propagation, pagination, and review hygiene.
+
+Read this when onboarding to V2 Go style. Most fga-sync work does not need it.
+
+## Domain errors and HTTP/transport mapping
+
+- Prefer typed domain errors over sentinel `errors.New` strings.
+- New code should preserve the shared V2 mapping at the transport boundary: validation to 400, not found to 404, conflict to 409, internal to 500, unavailable to 503.
+- Wrap upstream errors with `%w` so `errors.Is` and `errors.Unwrap` still work.
+- Translate domain errors at the transport boundary. Do not return raw upstream HTTP errors or third-party SDK payloads to the caller.
+- Do not introduce a parallel sentinel-error family if the repo already has typed domain errors. fga-sync currently returns handler errors to the NATS subscription loop for logging, with subject-specific replies only where documented (`read_tuples` JSON errors and access-check text errors).
+
+## Request context
+
+- Construct or accept `context.Context` at every public function boundary that does I/O. `context.Background()` is acceptable at the top of a NATS handler before any plumbing exists; pass it through to `FgaService` calls and to slog `*Context` methods.
+- Use typed context keys or constants; do not use bare strings.
+- Forward context values into downstream calls (NATS, OpenFGA, HTTP) only when the receiving contract needs them.
+- Do not read HTTP headers from service-layer code. Middleware owns request-context setup.
+
+## Pagination (for V2 services that expose list endpoints)
+
+- Standard list shape is `page_size` and opaque `page_token`.
+- Default `page_size` is 50; the maximum is normally 1000.
+- Return a next `page_token` only when another page exists.
+- `page_token` is opaque to clients; service owns its encoding.
+- Wrapper services translate upstream pagination to this shape at the service boundary.
+
+fga-sync currently exposes no public list endpoints; the `lfx.access_check.read_tuples` handler paginates internally against OpenFGA and returns the full result set in one reply.
+
+## Tests (shared V2 patterns)
+
+- Depend on interfaces for external systems: NATS clients, OpenFGA clients, KV stores, HTTP clients. fga-sync's equivalents are `INatsMsg`, `FgaService`, and the KV bucket interface; mocks live in `mock.go`.
+- Keep mocks in the repo's existing mock layout.
+- Use table-driven tests for branching behavior; one test function per exported method with cases added to the table.
+- Co-locate `*_test.go` with the file under test.
+- Run the repo's normal test target (`make test`) before handing off. Use race detection when the target supports it.
+
+## Formatting and review hygiene
+
+- Run `gofmt`/`goimports` via the repo's formatter target, `make fmt`.
+- Run the repo's lint target, `make lint` (golangci-lint), when Go code changes. `make check` runs format, vet, and lint.
+- Preserve required license headers on new files (`// Copyright The Linux Foundation and each contributor to LFX.` plus `// SPDX-License-Identifier: MIT`).
+- Document exported Go symbols when the linter requires it; otherwise add comments only where the code is not self-explanatory.
+- Update repo-owned docs or contracts in the same change as code that changes behavior. For fga-sync that means `docs/fga-sync-contract.md` for any subject, envelope, reply, or cache-protocol change.

--- a/.claude/skills/fga-sync-dev/references/nats-messaging.md
+++ b/.claude/skills/fga-sync-dev/references/nats-messaging.md
@@ -1,0 +1,35 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# NATS Messaging (fga-sync consumer)
+
+Read `lfx-skills:lfx-platform-architecture` for cross-repo NATS and KV ownership and the access-check flow. Read `docs/fga-sync-contract.md` for the `GenericFGAMessage` envelope, tuple format, and cache-invalidation contract. This file lists only what fga-sync subscribes to and how it replies.
+
+## Subscriptions
+
+All subscriptions are wired in `createQueueSubscriptions` in `main.go` and share the queue group `constants.FgaSyncQueue` (`"lfx.fga-sync.queue"`). Only one replica handles each message when scaled horizontally.
+
+| Subject (constant) | Value | Handler | Purpose |
+| --- | --- | --- | --- |
+| `AccessCheckSubject` | `lfx.access_check.request` | `accessCheckHandler` | Batch access check (used by query-service) |
+| `ReadTuplesSubject` | `lfx.access_check.read_tuples` | `readTuplesHandler` | Read direct tuples for a user + object type |
+| `GenericUpdateAccessSubject` | `lfx.fga-sync.update_access` | `genericUpdateAccessHandler` | Full sync of all relations for a resource |
+| `GenericDeleteAccessSubject` | `lfx.fga-sync.delete_access` | `genericDeleteAccessHandler` | Remove all relations on resource delete |
+| `GenericMemberPutSubject` | `lfx.fga-sync.member_put` | `genericMemberPutHandler` | Add or update a per-user relation |
+| `GenericMemberRemoveSubject` | `lfx.fga-sync.member_remove` | `genericMemberRemoveHandler` | Remove a per-user relation |
+
+Subject strings live in `pkg/constants/nats.go`. Do not hardcode them at call sites.
+
+## Reply semantics
+
+- `lfx.access_check.request`: plain text, one line per requested check, tab-delimited `{object}#{relation}@user:{principal}\t{true|false}`. Missing lines mean denied. Replies are not ordered; callers must match by request token.
+- `lfx.access_check.read_tuples`: JSON. Success is `{"results": ["object#relation@user:{principal}", ...]}`. Failure is `{"error": "..."}`.
+- `lfx.fga-sync.*`: `OK` on success only when `message.Reply() != ""`. Failures are returned to `subscribeToSubject` for logging with `subject` and `queue`; there is no standardized NATS error body for sync-subject failures.
+
+## When adding a new subscription
+
+1. Add the subject string to `pkg/constants/nats.go` with a doc comment that includes the wire value.
+2. Add a `HandlerFunc` to one of the `handler_*.go` files; sign it with `INatsMsg`, not `*nats.Msg`, so tests can drive it from `mock.go`.
+3. Append a `subscriptionConfig` entry to the slice in `createQueueSubscriptions` in `main.go`.
+4. Add a row above and reflect the reply shape in `docs/fga-sync-contract.md` if the subject is part of the cross-repo contract.
+5. Add table-driven tests in `handler_*_test.go` using the existing mocks.

--- a/.claude/skills/fga-tuple-emission/SKILL.md
+++ b/.claude/skills/fga-tuple-emission/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: fga-tuple-emission
+description: >
+  Use when a resource service emits FGA tuples after a CRUD, when building or
+  changing a `GenericFGAMessage` envelope, when debugging access checks ("user
+  can't see X they should"), when editing fga-sync handlers, or when touching
+  OpenFGA model boundaries or cache invalidation. This is the authoritative FGA
+  contract skill: it covers both the publisher (per-service emission) side and
+  the fga-sync handler side. Distinct from the `lfx-v2-fga-sync` repo as a
+  deployment surface; this skill is about the tuple-emission and handler
+  contract.
+allowed-tools: Read, Glob, Grep, Edit, Write
+paths:
+  - 'handler*.go'
+  - 'fga*.go'
+  - 'pkg/**'
+  - 'docs/fga*.md'
+  - 'docs/client-guide.md'
+---
+
+# FGA Access Control
+
+The platform uses ReBAC via OpenFGA. fga-sync is the single owner of tuple writes, cache, and access-check semantics. Resource services publish generic envelopes; this skill governs both sides of that contract.
+
+## Workflow
+
+1. **Read the authoritative contract** at `references/fga-patterns.md` (link
+   to `docs/fga-sync-contract.md`). Confirm the change does not
+   alter the `GenericFGAMessage` envelope, a generic subject, or the
+   cache-invalidation protocol.
+2. **Identify the change surface**:
+   - **Resource service publisher**: usually
+     `internal/infrastructure/nats/messaging_publish.go` or equivalent.
+   - **fga-sync handler**: the root-level `handler_*.go` files (single `package main`; no `handlers/` subdir).
+   - **OpenFGA model**: `lfx-v2-helm/charts/lfx-platform/templates/openfga/model.yaml`.
+   - **Heimdall ruleset**: the owning service's chart `templates/ruleset.yaml`.
+3. **For publisher changes**: ensure the envelope has correct `object_type`,
+   `operation` matching the subject suffix, full-sync `relations` (any key not
+   listed is removed), and `references` keyed by parent type. Bare UID values
+   are fine; the handler prepends the type prefix.
+4. **For member changes**: use `member_put` / `member_remove`. An empty
+   `relations` on `member_remove` removes ALL relations for that user, verify
+   that's what you want. Missing `username` is rejected by fga-sync; for
+   non-LFID members, document the limitation in the service's
+   `docs/fga-contract.md`.
+5. **For model changes** in `lfx-v2-helm`: see the Heimdall coordination
+   section in the central `/lfx-skills:lfx-platform-architecture` skill for the full
+   ordering across `model.yaml`, the per-service `ruleset.yaml`, and the
+   emitted access envelope. Ship them in coordinated PRs.
+6. **For debugging access** ("user can't see X"): walk the two-step debug
+   tree in `references/fga-patterns.md`, first OpenSearch (indexing or empty
+   `access_check_*` fields), then OpenFGA tuples (missing or wrong references,
+   cache staleness).
+7. **Update the per-service contract doc** at `docs/fga-contract.md` in the
+   owning service in the same PR as any publisher change.
+
+## Anti-patterns
+
+- Adding type-specific handlers in fga-sync. The handlers are generic; new
+  resource types do not require fga-sync code changes.
+- Calling OpenFGA directly from a resource service. Always go through
+  fga-sync via `lfx.fga-sync.*` subjects.
+- Assuming `lfx.access_check.request` results come back in order. Match on
+  the request token.
+- Forgetting the Heimdall ruleset update when adding a new FGA type.
+
+## References
+
+- `references/fga-patterns.md`: the authoritative access-control contract.

--- a/.claude/skills/fga-tuple-emission/references/fga-patterns.md
+++ b/.claude/skills/fga-tuple-emission/references/fga-patterns.md
@@ -1,0 +1,8 @@
+# FGA Patterns Reference
+
+This skill's reference content lives in the repo-owned canonical doc:
+
+`../../../../docs/fga-sync-contract.md`
+
+Read that file for the full `GenericFGAMessage` envelope, generic subjects,
+tuple format, model boundaries, cache behavior, and the two-step debug tree.

--- a/.cspell.json
+++ b/.cspell.json
@@ -15,6 +15,7 @@
   "words": [
     "golangci",
     "openfga",
+    "OPENSEARCH",
     "jetstream",
     "nats",
     "unittests",

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,16 @@ Thumbs.db
 # Claude AI assistant
 .claude
 
+# Commit repo-owned Claude skills while keeping other local Claude state ignored.
+!.claude/
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/fga-sync-dev/
+!.claude/skills/fga-sync-dev/**
+!.claude/skills/fga-tuple-emission/
+!.claude/skills/fga-tuple-emission/**
+
 # Environment and configuration files
 *.env*
 config.local.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> **Central LFX skills:**
+> - Start with `/lfx-skills:lfx` for cross-repo tasks, "where does X live" questions, owner/peer repo routing, or missing checkouts.
+> - Use `/lfx-skills:lfx-platform-architecture` for platform composition, V2 service classes, write/read/access-check flows, cross-service responsibilities, NATS/KV ownership, and the OpenFGA/Heimdall coordination order across `lfx-v2-helm`, owning services, and `lfx-v2-argocd`.
+> - The repo-local path-scoped `fga-sync-dev` skill auto-attaches on Go paths (`**/*.go`, `go.mod`, `go.sum`, `Makefile`, `pkg/**`, `charts/**`, `scripts/**`) and owns repo-local Go style for this service: single `package main` layout, slog wrapper, `INatsMsg`/`FgaService` mocks, generic resource-agnostic handlers, JetStream KV cache pattern, NATS queue-group conventions, tests, formatting, and linting.
+> - The repo-local `fga-tuple-emission` peer skill owns the publisher-side workflow (resource services emitting `GenericFGAMessage`) and the fga-sync handler side of that contract.
+> - **This repo owns the FGA tuple-emission contract and the access-check contract.** Other V2 services route here for envelope shapes, generic subjects, tuple format, cache behavior, and `lfx.access_check.*` semantics. See `docs/fga-sync-contract.md` and `docs/fga-protected-types.md`.
+> - Repo-owned docs under `docs/` are canonical for FGA Sync contracts, onboarding, and caller examples. If the plugin is missing, install with `/plugin marketplace add linuxfoundation/lfx-skills` then `/plugin install lfx-skills@lfx-skills`.
+
 ## Service Overview
 
 FGA Sync is a high-performance Go microservice that synchronizes authorization data between NATS messaging and OpenFGA (Fine-Grained Authorization). It provides cached relationship checks and real-time access control updates for the LFX Platform v2.
@@ -14,6 +22,35 @@ FGA Sync is a high-performance Go microservice that synchronizes authorization d
 - **OpenFGA Client**: Manages authorization relationships and batch operations
 - **JetStream Cache**: High-performance KeyValue store for relationship caching
 - **Health Endpoints**: Kubernetes-ready liveness and readiness probes
+
+## Agent Guidance
+
+Repo-owned guidance is split:
+
+- `docs/fga-sync-contract.md`: authoritative cross-repo contract. Generic FGA envelope, generic subjects, tuple format, cache behavior, model boundaries, and the two-step access-debug tree. Other repos read this.
+- `docs/fga-protected-types.md`: index of FGA-protected object types by service and the operations each one publishes.
+- `docs/client-guide.md`: NATS API reference for callers (request/reply queries, sync message formats, integration examples).
+- `docs/fga-catalog.md`: onboarding entry point for service owners adding FGA sync to a new resource service.
+- `.claude/skills/fga-sync-dev/`: repo-local Go conventions for fga-sync's own code (see Central LFX skills callout).
+- `.claude/skills/fga-tuple-emission/`: publisher-side workflow shared between resource services and fga-sync handlers.
+
+Read these before changing access sync behavior or advising resource services on emitted access messages.
+
+## Consumed Cross-Repo Contracts
+
+This repo depends on contracts owned elsewhere. Do not copy or infer them from
+local examples. Read the owner file before changing model coordination,
+indexing coordination, or publisher guidance.
+
+- OpenFGA model:
+  `lfx-v2-helm/charts/lfx-platform/templates/openfga/model.yaml`
+- Generic indexer event contract:
+  `lfx-v2-indexer-service/docs/indexer-contract.md`
+- Per-resource FGA emission contracts:
+  `<resource-service>/docs/fga-contract.md`
+
+Use `/lfx-skills:lfx` if an owner repo is missing locally, the path has moved,
+or the task needs additional peer repos.
 
 ### Message Flow
 
@@ -30,28 +67,14 @@ FGA Sync is a high-performance Go microservice that synchronizes authorization d
 
 ## Common Development Commands
 
-```bash
-# Build and test
-make build          # Build the fga-sync binary
-make test           # Run all tests
-make test-coverage  # Run tests with coverage report
-make check          # Format, vet, lint, and security scan
+The full target list lives in the `Makefile` (run `make help`). The path-scoped
+`fga-sync-dev` skill auto-attaches on Go paths and owns the canonical
+build/test/lint workflow. Quick reference:
 
-# Development
-make dev           # Build with debug symbols and race detection
-make run           # Build and run the service locally
-make clean         # Clean build artifacts
-
-# Docker operations
-make docker-build  # Build Docker image
-make docker-run    # Run service in Docker container
-
-# Code quality
-make fmt           # Format Go code
-make lint          # Run golangci-lint
-make vet           # Run go vet
-make gosec         # Run security scanner
-```
+- `make build` / `make run` / `make dev` (build with debug symbols)
+- `make test` / `make test-coverage`
+- `make check` (runs `fmt`, `vet`, `lint`)
+- `make docker-build`, `make helm-install-local`
 
 ## Configuration
 
@@ -65,136 +88,53 @@ make gosec         # Run security scanner
 ### Optional Environment Variables
 
 - `CACHE_BUCKET`: JetStream KeyValue bucket name (default: `fga-sync-cache`)
+- `USE_CACHE`: Enable JetStream KV reads for access checks when set to `true`
+  (chart default is true; binary default is false)
 - `PORT`: HTTP server port (default: `8080`)
 - `DEBUG`: Enable debug logging (default: `false`)
 
 ## Message Formats
 
-### Access Check Request (`lfx.access_check.request`)
+Full message format details (access check request/response, read-tuples,
+generic sync envelope, tuple-format rejection conditions) live in
+[`docs/fga-sync-contract.md`](docs/fga-sync-contract.md),
+the canonical FGA contract owned by this repo. Read that file before changing
+any subject, envelope shape, or reply contract.
 
-```
-project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456
-project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456
-```
-
-Multiple relationship checks, one per line. Format: `object#relation@user`
-
-Response is plain text, one line per check, tab-delimited `{request}\t{true|false}`. Order is not guaranteed — cached results are returned first.
-
-### Read Tuples Request (`lfx.access_check.read_tuples`)
-
-Returns all direct OpenFGA tuples for a given user and object type. Paginates internally.
-
-**Request:**
-
-```json
-{"user": "user:auth0|alice", "object_type": "project"}
-```
-
-**Response (success):**
-
-```json
-{"results": ["project:uuid1#writer@user:auth0|alice", "project:uuid2#auditor@user:auth0|alice"]}
-```
-
-**Response (error):**
-
-```json
-{"error": "failed to read tuples"}
-```
-
-### Generic Sync Message Format (`lfx.fga-sync.*`)
-
-New integrations should use the generic subjects. All use the `GenericFGAMessage` envelope:
-
-```json
-{
-  "object_type": "your_resource_type",
-  "operation": "operation_name",
-  "data": { /* operation-specific fields */ }
-}
-```
-
-Subjects: `lfx.fga-sync.update_access`, `lfx.fga-sync.delete_access`, `lfx.fga-sync.member_put`,
-`lfx.fga-sync.member_remove`. See `docs/client-guide.md` for full format details, examples, and best practices.
-
-If a reply subject is provided, sync handlers respond with `OK` after processing, allowing callers to implement
-synchronous acknowledgement.
+For the full per-operation reference and best practices, see
+[`docs/client-guide.md`](docs/client-guide.md).
 
 ## Testing
 
-### Running Tests
+Use `make test` (or `make test-coverage` for an HTML report). Test files are
+co-located with the file under test (`handler_access_test.go` next to
+`handler_access.go`, etc.) and drive handlers via the `INatsMsg` and `FgaService`
+mocks in `mock.go`. There is no in-repo integration suite; integration coverage
+lives in the platform stack via `lfx-v2-helm` and `load-mock-data`.
 
-```bash
-# Run all tests
-go test ./...
-
-# Run specific test
-go test -v ./... -run TestAccessCheckHandler
-
-# Run benchmarks
-go test -bench=. ./...
-
-# Integration tests (requires Docker)
-./test_integration.sh
-```
-
-### Test Structure
-
-- `*_test.go` files contain unit tests for each handler
-- `test_integration.sh` runs full service integration tests
-- `docker-compose.test.yml` provides test environment with NATS and OpenFGA
+The path-scoped `fga-sync-dev` skill auto-attaches on `**/*_test.go`
+and owns the table-driven test pattern and mocking conventions.
 
 ## Code Architecture
 
-### Handler Pattern
+Handler shape, `FgaService` abstraction rules, JetStream KV cache pattern, error handling, NATS queue-group conventions, slog usage, and the table-driven test pattern with `INatsMsg`/`FgaService` mocks all live in the path-scoped `fga-sync-dev` skill at `.claude/skills/fga-sync-dev/SKILL.md`. It auto-attaches when you open any Go file in this repo.
 
-Each message type has a dedicated handler function:
+Key invariants enforced there:
 
-- `accessCheckHandler()` - Processes authorization queries with caching
-- `readTuplesHandler()` - Returns all direct OpenFGA tuples for a user + object type
-- `genericUpdateAccessHandler()` - Generic resource permission sync (any object type)
-- `genericDeleteAccessHandler()` - Generic resource permission cleanup
-- `genericMemberPutHandler()` - Generic per-user relation add with multi-relation and mutual exclusion support
-- `genericMemberRemoveHandler()` - Generic per-user relation removal
+- All sync handlers are generic over `GenericFGAMessage`; new resource types must NOT require fga-sync code changes.
+- `FgaService` stays object-agnostic; domain logic lives in handlers.
+- Subject strings, queue group (`lfx.fga-sync.queue`), and KV bucket name come from `pkg/constants`, never inlined at call sites.
+- Cache invalidation uses a single `inv` timestamp key; every successful OpenFGA write must bump it.
+- Service continues running on individual message failures; sync handlers return errors for subscription-layer logging and only send `OK` replies after successful processing.
 
-### Service Abstraction
+## Performance and Observability
 
-**FgaService should remain generic and object-agnostic:**
-
-- FgaService should not contain business logic specific to projects, meetings, or other domain objects
-- It should only provide generic tuple management operations (read, write, delete, sync)
-- All business-specific logic should remain in the handlers
-- This maintains clean separation of concerns and reusability
-
-### Cache Strategy
-
-- **Cache Keys**: Base32-encoded relation tuples (e.g., `rel.{encoded-relation}`)
-- **Cache Values**: JSON with `allowed` boolean and `created_at` timestamp
-- **Invalidation**: Timestamp-based with configurable staleness tolerance
-- **Fallback**: Direct OpenFGA queries on cache miss
-
-### Error Handling
-
-- Structured logging with context
-- Graceful degradation (cache miss → OpenFGA query)
-- Message reply with error details for debugging
-- Service continues running on individual message failures
-
-## Performance Considerations
-
-### Optimization Patterns
-
-- Preallocated slices to reduce garbage collection
-- Batch OpenFGA operations (up to 100 tuples per request)
-- Cache-first approach with sub-millisecond response times
-- Efficient string parsing using `bytes.Cut`
-
-### Monitoring
-
-- Expvar metrics at `/debug/vars` (cache hits/misses/stale hits)
-- Structured JSON logging for observability
-- Health endpoints for Kubernetes probes
+- Batch OpenFGA operations (up to 100 tuples per request); cache-first reads via
+  the JetStream KV bucket. See `docs/fga-sync-contract.md` for cache
+  behavior and invalidation semantics.
+- Expvar counters at `/debug/vars`: `cache_hits`, `cache_misses`, `cache_stale_hits`.
+- Health endpoints `/livez` and `/readyz` for Kubernetes probes.
+- Structured JSON logging via the slog wrapper (see `fga-sync-dev` skill).
 
 ## Deployment
 
@@ -224,16 +164,10 @@ helm install fga-sync ./charts/lfx-v2-fga-sync \
 
 ## Troubleshooting
 
-### Common Issues
-
-- **Build failures**: Ensure Go 1.24+ and run `go mod tidy`
-- **NATS connection**: Verify NATS_URL and network connectivity
-- **OpenFGA errors**: Check OPENFGA_API_URL and ensure OpenFGA is healthy
-- **Cache issues**: Monitor cache hit rates via `/debug/vars`
-
-### Debugging
-
-- Set `DEBUG=true` for verbose logging
-- Check service health at `/livez` and `/readyz`
-- Monitor Docker container logs for connection issues
-- Use `make check` to validate code quality before deployment
+- **Build failures**: ensure Go matches `go.mod` (currently 1.25+) and run `go mod tidy`.
+- **NATS / OpenFGA connection**: verify `NATS_URL` and `OPENFGA_API_URL`.
+- **Cache or stale access checks**: see the cache behavior and "Debugging Access Issues"
+  sections in `docs/fga-sync-contract.md` (covers `/debug/vars` counters, the
+  `inv` invalidation key, and the `scripts/audit/list-tuple-changes` CLI).
+- **Verbose logging**: set `DEBUG=true`.
+- **Health**: `/livez` and `/readyz`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 > **Central LFX skills:**
 > - Start with `/lfx-skills:lfx` for cross-repo tasks, "where does X live" questions, owner/peer repo routing, or missing checkouts.
 > - Use `/lfx-skills:lfx-platform-architecture` for platform composition, V2 service classes, write/read/access-check flows, cross-service responsibilities, NATS/KV ownership, and the OpenFGA/Heimdall coordination order across `lfx-v2-helm`, owning services, and `lfx-v2-argocd`.
-> - The repo-local path-scoped `fga-sync-dev` skill auto-attaches on Go paths (`**/*.go`, `go.mod`, `go.sum`, `Makefile`, `pkg/**`, `charts/**`, `scripts/**`) and owns repo-local Go style for this service: single `package main` layout, slog wrapper, `INatsMsg`/`FgaService` mocks, generic resource-agnostic handlers, JetStream KV cache pattern, NATS queue-group conventions, tests, formatting, and linting.
+> - The repo-local path-scoped `fga-sync-dev` skill auto-attaches on Go paths (`**/*.go`, `go.mod`, `go.sum`, `Makefile`, `pkg/**`, `charts/**`, `scripts/**`) and owns repo-local Go style for this service: single `package main` layout, slog wrapper, `INatsMsg`/`IFgaClient` mocks, generic resource-agnostic handlers, JetStream KV cache pattern, NATS queue-group conventions, tests, formatting, and linting.
 > - The repo-local `fga-tuple-emission` peer skill owns the publisher-side workflow (resource services emitting `GenericFGAMessage`) and the fga-sync handler side of that contract.
 > - **This repo owns the FGA tuple-emission contract and the access-check contract.** Other V2 services route here for envelope shapes, generic subjects, tuple format, cache behavior, and `lfx.access_check.*` semantics. See `docs/fga-sync-contract.md` and `docs/fga-protected-types.md`.
 > - Repo-owned docs under `docs/` are canonical for FGA Sync contracts, onboarding, and caller examples. If the plugin is missing, install with `/plugin marketplace add linuxfoundation/lfx-skills` then `/plugin install lfx-skills@lfx-skills`.
@@ -80,7 +80,8 @@ build/test/lint workflow. Quick reference:
 
 ### Required Environment Variables
 
-- `NATS_URL`: NATS server connection URL (e.g., `nats://localhost:4222`)
+- `NATS_URL`: NATS server connection URL (e.g., `nats://localhost:4222`; binary
+  defaults to `nats://nats:4222` if unset)
 - `OPENFGA_API_URL`: OpenFGA API endpoint (e.g., `http://localhost:8080`)
 - `OPENFGA_STORE_ID`: OpenFGA store ID
 - `OPENFGA_AUTH_MODEL_ID`: OpenFGA authorization model ID
@@ -108,8 +109,8 @@ For the full per-operation reference and best practices, see
 
 Use `make test` (or `make test-coverage` for an HTML report). Test files are
 co-located with the file under test (`handler_access_test.go` next to
-`handler_access.go`, etc.) and drive handlers via the `INatsMsg` and `FgaService`
-mocks in `mock.go`. There is no in-repo integration suite; integration coverage
+`handler_access.go`, etc.) and drive handlers via the `INatsMsg` and `IFgaClient`
+mocks in `mock.go` (injected into a real `FgaService`). There is no in-repo integration suite; integration coverage
 lives in the platform stack via `lfx-v2-helm` and `load-mock-data`.
 
 The path-scoped `fga-sync-dev` skill auto-attaches on `**/*_test.go`

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ make helm-install-local
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| `NATS_URL` | NATS server connection URL | `nats://localhost:4222` | Yes |
+| `NATS_URL` | NATS server connection URL | `nats://nats:4222` | No |
 | `OPENFGA_API_URL` | OpenFGA API endpoint | - | Yes |
 | `OPENFGA_STORE_ID` | OpenFGA store ID | - | Yes |
 | `OPENFGA_AUTH_MODEL_ID` | OpenFGA authorization model ID | - | Yes |

--- a/README.md
+++ b/README.md
@@ -2,19 +2,25 @@
 
 ![Build Status](https://github.com/linuxfoundation/lfx-v2-fga-sync/workflows/FGA%20Sync%20Build/badge.svg)
 ![License](https://img.shields.io/badge/License-MIT-blue.svg)
-![Go Version](https://img.shields.io/badge/Go-1.23+-00ADD8?logo=go)
+![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)
 
 A high-performance microservice that synchronizes authorization data between NATS messaging and OpenFGA
 (Fine-Grained Authorization), providing cached relationship checks and real-time access control updates for the
 LFX Platform v2.
 
+> Agents working in this repo should start with [`CLAUDE.md`](CLAUDE.md).
+> The authoritative FGA Sync contract lives in
+> [`docs/fga-sync-contract.md`](docs/fga-sync-contract.md); protected object
+> inventory lives in [`docs/fga-protected-types.md`](docs/fga-protected-types.md).
+> Service-owner onboarding lives in [`docs/fga-catalog.md`](docs/fga-catalog.md).
+
 ## 🚀 Features
 
-- **Real-time Authorization Sync**: Synchronizes project access permissions between NATS and OpenFGA
-- **High-Performance Caching**: JetStream-based caching with automatic invalidation for sub-millisecond response times
+- **Real-time Authorization Sync**: Synchronizes resource access tuples between NATS and OpenFGA
+- **Cache-first Access Checks**: JetStream KV caching with global timestamp invalidation
 - **Batch Operations**: Efficient bulk relationship checking and updates
 - **Health Monitoring**: Kubernetes-ready health checks and observability
-- **Security First**: Comprehensive security scanning and best practices
+- **Security First**: Non-root container image, CodeQL, MegaLinter, and pinned workflow actions
 
 ## 📋 Architecture
 
@@ -39,15 +45,15 @@ graph TB
 ### Components
 
 - **Access Check Handler**: Processes authorization queries with intelligent caching
-- **Resource Handlers**: Manages resource permission synchronization: updates, deletes
-(e.g. `handler_project.go` for project permission data)
+- **Generic Sync Handlers**: Manage `update_access`, `delete_access`,
+  `member_put`, and `member_remove` for any OpenFGA model-defined resource type
 - **Cache Layer**: JetStream KeyValue store for high-performance relationship caching
 
 ## 🛠️ Quick Start
 
 ### Prerequisites
 
-- Go 1.23+
+- Go 1.25+
 - Kubernetes 1.19+
 - Helm 3.2.0+
 - Docker (optional)
@@ -175,8 +181,10 @@ because otherwise access checks will use the cached access tuples even though th
 
 | Document | Description |
 | --- | --- |
-| [docs/client-guide.md](docs/client-guide.md) | NATS API reference — request/reply queries, sync message formats, and integration examples |
-| [docs/fga-catalog.md](docs/fga-catalog.md) | Index of all services publishing FGA sync messages, with links to their FGA contracts |
+| [docs/fga-sync-contract.md](docs/fga-sync-contract.md) | Authoritative generic FGA envelope, subjects, tuple format, cache behavior, and access-check semantics |
+| [docs/fga-protected-types.md](docs/fga-protected-types.md) | Inventory of services, object types, and supported FGA sync operations |
+| [docs/client-guide.md](docs/client-guide.md) | NATS API reference, request/reply queries, sync message formats, and integration examples |
+| [docs/fga-catalog.md](docs/fga-catalog.md) | Onboarding checklist for service owners adding FGA sync to a resource service |
 
 ## 📊 API Reference
 
@@ -243,7 +251,7 @@ make fmt
 # Run linter
 make lint
 
-# Run security checks
+# Run go vet
 make vet
 
 # Run all quality checks
@@ -265,24 +273,25 @@ make dev
 
 ## 📈 Performance
 
-- **Throughput**: 10,000+ relationship checks per second
-- **Latency**: Sub-millisecond response times with cache hits
-- **Cache Hit Rate**: >95% for typical workloads
-- **Memory Usage**: ~64MB baseline, scales with cache size
+This service uses cache-first access checks and batches OpenFGA writes in groups
+of up to 100 operations, matching the OpenFGA Write API limit. No benchmark
+numbers are claimed in this README; verify workload-specific throughput and
+latency in the target environment.
 
 ### Caching Strategy
 
 1. **Cache Key Format**: `rel.{base32-encoded-relation}`
-2. **Cache Invalidation**: Timestamp-based with automatic cleanup
-3. **Cache TTL**: Configurable via JetStream bucket settings
-4. **Fallback**: Direct OpenFGA queries on cache miss
+2. **Cache Values**: raw `true` / `false` strings; freshness comes from NATS KV entry timestamps
+3. **Cache Invalidation**: global `inv` timestamp marker written after successful OpenFGA writes
+4. **Cache TTL**: Configurable via JetStream bucket settings
+5. **Fallback**: Direct OpenFGA queries on cache miss or stale hit
 
 ## 🛡️ Security
 
-- **Principle of Least Privilege**: Runs as non-root user (nobody)
-- **Read-only Filesystem**: Container uses read-only root filesystem
-- **Security Scanning**: Automated vulnerability scanning with Trivy and Gosec
-- **Secret Management**: No secrets stored in code or environment variables
+- **Principle of Least Privilege**: Runs as a non-root user in the runtime image
+- **Minimal Runtime Image**: Uses Chainguard static runtime image for the final container
+- **Security Scanning**: Automated CodeQL and MegaLinter workflows
+- **Secret Management**: No secrets should be committed; deployment-owned values come from environment or cluster injection
 
 ## 🔍 Monitoring
 
@@ -291,7 +300,7 @@ make dev
 The service exposes metrics via expvar at `/debug/vars`:
 
 - `cache_hits` - Number of successful cache lookups
-- `cache_stale_hits` - Number of stale cache entries used
+- `cache_stale_hits` - Number of stale cache entries detected and rechecked
 - `cache_misses` - Number of cache misses requiring OpenFGA queries
 
 ### Logging
@@ -342,7 +351,7 @@ fga:
 
 ### Creating a Release
 
-To create a new release of the project service:
+To create a new release of the fga-sync service:
 
 1. **Update the chart version** in `charts/lfx-v2-fga-sync/Chart.yaml` prior to any project releases, or if any
    change is made to the chart manifests or configuration:

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -1,6 +1,9 @@
 # FGA Sync Client Guide
 
 This guide explains how to use the FGA Sync service's NATS API to manage fine-grained authorization for your resources.
+It is a caller-facing walkthrough. The authoritative generic subjects, envelope
+shape, tuple format, cache behavior, and access-check semantics live in
+[`docs/fga-sync-contract.md`](fga-sync-contract.md).
 
 ## Request/Reply API
 
@@ -62,16 +65,17 @@ If no tuples are found:
 
 ## Sync API — Generic Handlers
 
-The FGA Sync service provides four universal NATS subjects that work with **any resource type** (projects,
-committees, meetings, etc.). If a reply subject is provided, the service responds with `OK` after processing,
-allowing callers to implement synchronous acknowledgement.
+The FGA Sync service provides four universal NATS subjects that work with any
+resource type defined in the OpenFGA model, such as projects, committees, and
+v1 meetings. If a reply subject is provided, the service responds with `OK`
+after processing, allowing callers to implement synchronous acknowledgement.
 
 ### Benefits of Generic Handlers
 
-- ✅ **Resource Agnostic** - Works with any object type
+- ✅ **Resource Agnostic** - Works with any model-defined object type
 - ✅ **Multiple Relations** - Add/remove multiple relations atomically
 - ✅ **Mutually Exclusive Relations** - Automatic cleanup of conflicting roles
-- ✅ **Future Proof** - New resource types require no service changes
+- ✅ **Future Proof** - New model-defined resource types require no fga-sync service changes
 - ✅ **Consistent API** - Same pattern for all operations
 
 ---
@@ -104,7 +108,7 @@ All messages use the **GenericFGAMessage** envelope:
 ### Fields
 
 - **`object_type`** *(required, string)* - Your resource type, must be defined in the [OpenFGA authorization model](https://github.com/linuxfoundation/lfx-v2-helm/blob/main/charts/lfx-platform/templates/openfga/model.yaml)
-  - Examples: `"committee"`, `"project"`, `"meeting"`
+  - Examples: `"committee"`, `"project"`, `"v1_meeting"`, `"v1_past_meeting"`
 - **`operation`** *(required, string)* - Must match the NATS subject operation without the `lfx.fga-sync.` prefix
   - Example: If sending to `lfx.fga-sync.update_access`, this must be `"update_access"`
 - **`data`** *(required, object)* - Operation-specific payload (see below)
@@ -223,7 +227,7 @@ Use `exclude_relations` when some relations are managed by separate member opera
 
 ```json
 {
-  "object_type": "meeting",
+  "object_type": "v1_meeting",
   "operation": "update_access",
   "data": {
     "uid": "meeting-789",
@@ -324,7 +328,7 @@ Deletes **all** access control tuples for a resource. Typically used when a reso
 
 ```json
 {
-  "object_type": "meeting",
+  "object_type": "v1_meeting",
   "operation": "delete_access",
   "data": {
     "uid": "meeting-456"
@@ -404,7 +408,7 @@ Add both `host` and `invitee` relations in a single atomic operation:
 
 ```json
 {
-  "object_type": "past_meeting",
+  "object_type": "v1_past_meeting",
   "operation": "member_put",
   "data": {
     "uid": "past-meeting-456",
@@ -420,7 +424,7 @@ When promoting a participant to host, automatically remove the `participant` rel
 
 ```json
 {
-  "object_type": "meeting",
+  "object_type": "v1_meeting",
   "operation": "member_put",
   "data": {
     "uid": "meeting-789",
@@ -461,7 +465,7 @@ msg := GenericFGAMessage{
 
 // Multiple relations
 msg := GenericFGAMessage{
-    ObjectType: "past_meeting",
+    ObjectType: "v1_past_meeting",
     Operation:  "member_put",
     Data: MemberData{
         UID:       "past-meeting-456",
@@ -472,7 +476,7 @@ msg := GenericFGAMessage{
 
 // Mutually exclusive
 msg := GenericFGAMessage{
-    ObjectType: "meeting",
+    ObjectType: "v1_meeting",
     Operation:  "member_put",
     Data: MemberData{
         UID:                   "meeting-789",
@@ -523,7 +527,7 @@ Remove only the `invitee` relation, keeping other relations intact:
 
 ```json
 {
-  "object_type": "past_meeting",
+  "object_type": "v1_past_meeting",
   "operation": "member_remove",
   "data": {
     "uid": "past-meeting-456",
@@ -537,7 +541,7 @@ Remove only the `invitee` relation, keeping other relations intact:
 
 ```json
 {
-  "object_type": "past_meeting",
+  "object_type": "v1_past_meeting",
   "operation": "member_remove",
   "data": {
     "uid": "past-meeting-456",
@@ -689,7 +693,7 @@ nc.Request("lfx.fga-sync.member_remove", payload, 5*time.Second)
 
 ```json
 {
-  "object_type": "meeting",
+  "object_type": "v1_meeting",
   "operation": "update_access",
   "data": {
     "uid": "meeting-2026-01-15",
@@ -712,7 +716,7 @@ nc.Request("lfx.fga-sync.member_remove", payload, 5*time.Second)
 
 ```json
 {
-  "object_type": "meeting",
+  "object_type": "v1_meeting",
   "operation": "member_put",
   "data": {
     "uid": "meeting-2026-01-15",
@@ -726,7 +730,7 @@ nc.Request("lfx.fga-sync.member_remove", payload, 5*time.Second)
 
 ```json
 {
-  "object_type": "meeting",
+  "object_type": "v1_meeting",
   "operation": "member_put",
   "data": {
     "uid": "meeting-2026-01-15",
@@ -743,7 +747,7 @@ nc.Request("lfx.fga-sync.member_remove", payload, 5*time.Second)
 
 ```json
 {
-  "object_type": "meeting",
+  "object_type": "v1_meeting",
   "operation": "member_remove",
   "data": {
     "uid": "meeting-2026-01-15",
@@ -763,7 +767,7 @@ A participant can have multiple roles (invitee, attendee, host):
 
 ```json
 {
-  "object_type": "past_meeting",
+  "object_type": "v1_past_meeting",
   "operation": "member_put",
   "data": {
     "uid": "past-meeting-123",
@@ -779,7 +783,7 @@ Remove `attendee` if they didn't actually attend:
 
 ```json
 {
-  "object_type": "past_meeting",
+  "object_type": "v1_past_meeting",
   "operation": "member_remove",
   "data": {
     "uid": "past-meeting-123",
@@ -795,13 +799,17 @@ Remove `attendee` if they didn't actually attend:
 
 ## Response Format
 
-All operations return a simple `"OK"` string on success:
+Sync operations return a simple `"OK"` string on success when the request
+includes a reply subject:
 
 ```text
 OK
 ```
 
-Errors are logged server-side and returned as error messages in the NATS reply.
+Sync-operation failures are logged server-side by the subscription loop. They do
+not currently have a standardized NATS error response body, so callers using
+request/reply should treat a missing `OK` as failure and apply their normal
+timeout/retry handling.
 
 ---
 
@@ -826,7 +834,7 @@ When a user needs multiple relations, send them in one `member_put` operation:
 ```json
 // ✅ Good: Atomic operation
 {
-  "object_type": "past_meeting",
+  "object_type": "v1_past_meeting",
   "operation": "member_put",
   "data": {
     "uid": "meeting-123",
@@ -893,17 +901,17 @@ To remove all relations for a user, use an empty `relations` array:
 
 ## Performance Characteristics
 
-Based on production testing:
+The repo does not publish canonical latency numbers. In general:
 
-| Operation | Average Response Time | Notes |
-|-----------|----------------------|-------|
-| `update_access` | 30-60ms | Depends on number of relations |
-| `delete_access` | 7-10ms | Fast deletion |
-| `member_put` (new) | 8-11ms | Creates new tuple |
-| `member_put` (existing) | 5-6ms | Idempotent, skips write |
-| `member_put` (mutually exclusive) | 80-90ms | Extra read/delete operations |
-| `member_remove` (specific) | 8-9ms | Deletes specific tuples |
-| `member_remove` (all) | 8-9ms | Deletes all user tuples |
+| Operation | Cost driver |
+|-----------|-------------|
+| `update_access` | Reads current object tuples, computes diff, writes/deletes changed tuples |
+| `delete_access` | Reads current object tuples, then deletes all tuples for the object |
+| `member_put` (new) | Reads current object tuples, writes missing relations |
+| `member_put` (existing) | Reads current object tuples, skips writes when relations already exist |
+| `member_put` (mutually exclusive) | Reads current object tuples, deletes mutually exclusive relations, writes desired relations |
+| `member_remove` (specific) | Deletes specific tuples without a full-object sync |
+| `member_remove` (all) | Reads tuples for the user/object pair, then deletes them |
 
 ---
 
@@ -974,7 +982,10 @@ A: Send `member_remove` with an empty relations array: `"relations": []`
 A: `update_access` is a full sync (sets complete state), while `member_put` adds specific relations incrementally.
 
 **Q: Can I use any object_type value?**
-A: Yes! The handlers are resource-agnostic. Use any string like `"committee"`, `"project"`, `"working_group"`, etc.
+A: Use any object type that is defined in the OpenFGA model, such as
+`"committee"`, `"project"`, `"v1_meeting"`, or `"v1_past_meeting"`. Unknown
+or invalid tuple writes are logged and skipped by the OpenFGA validation retry
+path; non-validation OpenFGA errors fail the operation.
 
 ---
 

--- a/docs/fga-catalog.md
+++ b/docs/fga-catalog.md
@@ -1,35 +1,31 @@
 # FGA Contract Catalog
 
-This document is the index of all services that publish FGA sync messages to this service, organized by service.
+This page is the onboarding entry point for service owners adding FGA sync to a
+new resource service. For the full list of FGA-protected object types and the
+operations each service supports, see
+[`docs/fga-protected-types.md`](fga-protected-types.md).
 
-Each service owns its FGA contract — the authoritative reference for the object types it manages, the NATS subjects
-it publishes to, and the payload shape for each operation. When a service's access control logic changes, only that
-service's contract needs updating.
-
----
-
-## Services
-
-The "Object Types" column lists the `object_type` string values carried in each FGA sync message payload — these
-match the type prefixes defined in `pkg/constants/fga.go` (without the trailing colon used internally).
-
-| Service | Object Types | FGA Contract |
-|---|---|---|
-| [lfx-v2-project-service](https://github.com/linuxfoundation/lfx-v2-project-service) | `project` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-project-service/blob/main/docs/fga-contract.md) |
-| [lfx-v2-committee-service](https://github.com/linuxfoundation/lfx-v2-committee-service) | `committee` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/fga-contract.md) |
-| [lfx-v2-meeting-service](https://github.com/linuxfoundation/lfx-v2-meeting-service) | `v1_meeting`, `v1_past_meeting` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/fga-contract.md) |
-| [lfx-v2-voting-service](https://github.com/linuxfoundation/lfx-v2-voting-service) | `vote`, `vote_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-voting-service/blob/main/docs/fga-contract.md) |
-| [lfx-v2-survey-service](https://github.com/linuxfoundation/lfx-v2-survey-service) | `survey`, `survey_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-survey-service/blob/main/docs/fga-contract.md) |
-| [lfx-v2-mailing-list-service](https://github.com/linuxfoundation/lfx-v2-mailing-list-service) | `groupsio_service`, `groupsio_mailing_list` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/blob/main/docs/fga-contract.md) |
-
----
+Each service owns its FGA contract (`docs/fga-contract.md` in that repo), which
+is the authoritative reference for the object types it manages, the NATS
+subjects it publishes to, and the payload shape for each operation. When a
+service's access control logic changes, update that service's contract; update
+this repo's protected-types inventory only when the service's object types or
+supported operations change.
 
 ## Adding a New Service
 
 When a new service starts publishing FGA sync messages:
 
-1. Add a `docs/fga-contract.md` to that service's repo following the [committee-service pattern](https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/fga-contract.md)
-2. Add a row to the table above with the service name, object types, and a link to its contract
+1. Add or update `docs/fga-contract.md` in that service's repo. Use an
+   existing resource service as a shape-only example, but do not copy
+   service-specific relations or references; the target service owns its own
+   contract.
+2. Add a row to the service table in
+   [`docs/fga-protected-types.md`](fga-protected-types.md)
+   with the service name, object types, and a link to its contract.
 
-All integrations must publish to the generic `lfx.fga-sync.*` subjects.
-See the [client guide](client-guide.md) for message format details.
+All integrations must publish to the generic `lfx.fga-sync.*` subjects. See the
+[client guide](client-guide.md) for caller examples, and
+[`docs/fga-sync-contract.md`](fga-sync-contract.md) for the authoritative
+generic subjects, envelope shape, tuple format, cache behavior, and
+access-check semantics.

--- a/docs/fga-catalog.md
+++ b/docs/fga-catalog.md
@@ -14,8 +14,9 @@ service's object types or supported operations change.
 
 ## Services
 
-The "Object Types" column lists the `object_type` string values carried in each FGA sync message payload — these
-match the type prefixes defined in `pkg/constants/fga.go` (without the trailing colon used internally).
+The "Object Types" column lists the `object_type` string values carried in each FGA sync message payload. fga-sync's
+handlers are generic and do not require a constant per type; where `pkg/constants/fga.go` does define a type prefix,
+it matches these values (without the trailing colon used internally).
 
 | Service | Object Types | FGA Contract |
 |---|---|---|

--- a/docs/fga-protected-types.md
+++ b/docs/fga-protected-types.md
@@ -1,0 +1,105 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# FGA-Protected Resource Types in LFX V2
+
+All access control for LFX V2 resources is enforced through OpenFGA (Fine-Grained
+Authorization). Resource services publish FGA sync messages to `lfx.fga-sync.*` NATS
+subjects, which are consumed by `lfx-v2-fga-sync`.
+
+**How to find all types**: check each backend service's `docs/fga-contract.md` for the
+object types it manages, the NATS subjects it publishes to, and the payload shape for
+each operation.
+
+For human onboarding (adding a new service to this list), see
+[`lfx-v2-fga-sync/docs/fga-catalog.md`](https://github.com/linuxfoundation/lfx-v2-fga-sync/blob/main/docs/fga-catalog.md).
+
+---
+
+## Services
+
+| Service | Object Types | FGA Contract |
+|---|---|---|
+| [lfx-v2-project-service](https://github.com/linuxfoundation/lfx-v2-project-service) | `project` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-project-service/blob/main/docs/fga-contract.md) |
+| [lfx-v2-committee-service](https://github.com/linuxfoundation/lfx-v2-committee-service) | `committee` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/fga-contract.md) |
+| [lfx-v2-meeting-service](https://github.com/linuxfoundation/lfx-v2-meeting-service) | `v1_meeting`, `v1_past_meeting` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/fga-contract.md) |
+| [lfx-v2-voting-service](https://github.com/linuxfoundation/lfx-v2-voting-service) | `vote`, `vote_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-voting-service/blob/main/docs/fga-contract.md) |
+| [lfx-v2-survey-service](https://github.com/linuxfoundation/lfx-v2-survey-service) | `survey`, `survey_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-survey-service/blob/main/docs/fga-contract.md) |
+| [lfx-v2-mailing-list-service](https://github.com/linuxfoundation/lfx-v2-mailing-list-service) | `groupsio_service`, `groupsio_mailing_list` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/blob/main/docs/fga-contract.md) |
+
+---
+
+## FGA Object Types by Domain
+
+Services that have a `docs/fga-contract.md` provide the full message schema, operations,
+relations, and trigger conditions for their object types. Use it as the authoritative
+reference when writing or reviewing access control code for that service.
+
+### Projects: `lfx-v2-project-service`
+
+FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-project-service/blob/main/docs/fga-contract.md)
+
+| Object type | Operations |
+|-------------|------------|
+| `project` | `update_access`, `delete_access` |
+
+### Committees: `lfx-v2-committee-service`
+
+FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/fga-contract.md)
+
+| Object type | Operations |
+|-------------|------------|
+| `committee` | `update_access`, `delete_access`, `member_put`, `member_remove` |
+
+### Meetings: `lfx-v2-meeting-service`
+
+FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/fga-contract.md)
+
+| Object type | Operations |
+|-------------|------------|
+| `v1_meeting` | `update_access`, `delete_access`, `member_put`, `member_remove` |
+| `v1_past_meeting` | `update_access`, `delete_access`, `member_put`, `member_remove` |
+
+### Voting: `lfx-v2-voting-service`
+
+FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-voting-service/blob/main/docs/fga-contract.md)
+
+| Object type | Operations |
+|-------------|------------|
+| `vote` | `update_access`, `delete_access` |
+| `vote_response` | `update_access`, `delete_access` |
+
+### Surveys: `lfx-v2-survey-service`
+
+FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-survey-service/blob/main/docs/fga-contract.md)
+
+| Object type | Operations |
+|-------------|------------|
+| `survey` | `update_access`, `delete_access` |
+| `survey_response` | `update_access`, `delete_access` |
+
+### Mailing Lists: `lfx-v2-mailing-list-service`
+
+FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/blob/main/docs/fga-contract.md)
+
+| Object type | Operations |
+|-------------|------------|
+| `groupsio_service` | `update_access`, `delete_access` |
+| `groupsio_mailing_list` | `update_access`, `delete_access`, `member_put`, `member_remove` |
+
+---
+
+## NATS Subjects
+
+All services publish to these generic subjects consumed by `lfx-v2-fga-sync`:
+
+| Subject | Purpose |
+|---------|---------|
+| `lfx.fga-sync.update_access` | Sync all relations for a resource |
+| `lfx.fga-sync.delete_access` | Remove all relations when a resource is deleted |
+| `lfx.fga-sync.member_put` | Add or update a per-user relation on a resource |
+| `lfx.fga-sync.member_remove` | Remove a per-user relation from a resource |
+
+For the authoritative envelope and tuple contract, see
+[fga-sync-contract.md](fga-sync-contract.md). For caller examples, see
+[client-guide.md](client-guide.md).

--- a/docs/fga-protected-types.md
+++ b/docs/fga-protected-types.md
@@ -26,6 +26,7 @@ For human onboarding (adding a new service to this list), see
 | [lfx-v2-voting-service](https://github.com/linuxfoundation/lfx-v2-voting-service) | `vote`, `vote_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-voting-service/blob/main/docs/fga-contract.md) |
 | [lfx-v2-survey-service](https://github.com/linuxfoundation/lfx-v2-survey-service) | `survey`, `survey_response` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-survey-service/blob/main/docs/fga-contract.md) |
 | [lfx-v2-mailing-list-service](https://github.com/linuxfoundation/lfx-v2-mailing-list-service) | `groupsio_service`, `groupsio_mailing_list` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/blob/main/docs/fga-contract.md) |
+| [lfx-v2-member-service](https://github.com/linuxfoundation/lfx-v2-member-service) | `b2b_org`, `project_membership` | [fga-contract.md](https://github.com/linuxfoundation/lfx-v2-member-service/blob/main/docs/fga-contract.md) |
 
 ---
 
@@ -86,6 +87,19 @@ FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-m
 |-------------|------------|
 | `groupsio_service` | `update_access`, `delete_access` |
 | `groupsio_mailing_list` | `update_access`, `delete_access`, `member_put`, `member_remove` |
+
+### Members: `lfx-v2-member-service`
+
+FGA contract: [docs/fga-contract.md](https://github.com/linuxfoundation/lfx-v2-member-service/blob/main/docs/fga-contract.md)
+
+| Object type | Operations |
+|-------------|------------|
+| `b2b_org` | `update_access`, `delete_access` |
+| `project_membership` | `member_put`, `member_remove` |
+
+> `project_membership` only carries the `key_contact` relation, managed via
+> `member_put`/`member_remove`; the member service does not issue `update_access`
+> or `delete_access` for `project_membership` objects directly.
 
 ---
 

--- a/docs/fga-sync-contract.md
+++ b/docs/fga-sync-contract.md
@@ -96,7 +96,7 @@ type GenericFGAMessage struct {
 - `references` values can be bare UIDs (handler prepends the map key as the type
   prefix, e.g. `"project": ["abc"]` → `project:abc`) or full `type:uid` strings.
   Both are accepted.
-- `references.project` produces tuple `project:{project_uid}#project@committee:{committee_uid}`,
+- `references.project` produces tuple `committee:{committee_uid}#project@project:{project_uid}`,
   enabling permission inheritance from the parent project.
 - `exclude_relations` lets a publisher manage some relations separately (e.g. members
   managed by a different subject). Those relations are left untouched.
@@ -251,6 +251,11 @@ msg := GenericFGAMessage{
             "project": {resource.ProjectUID},
         },
     },
+}
+
+payload, err := json.Marshal(msg)
+if err != nil {
+    return err
 }
 nc.Publish("lfx.fga-sync.update_access", payload)
 ```

--- a/docs/fga-sync-contract.md
+++ b/docs/fga-sync-contract.md
@@ -29,15 +29,15 @@ envelope below.
 ## Tuple Format
 
 ```text
-{user_type}:{user_id}#{relation}@{object_type}:{object_id}
+{object_type}:{object_id}#{relation}@{user_type}:{user_id}
 ```
 
 Examples:
 
-- `user:alice#writer@project:proj-123`: alice is a writer on this project
-- `user:*#viewer@project:proj-123`: anyone (public) can view this project
-- `project:parent-123#parent@project:child-456`: parent-child hierarchy link
-- `user:bob#member@committee:abc`: bob is a member of this committee
+- `project:proj-123#writer@user:alice`: alice is a writer on this project
+- `project:proj-123#viewer@user:*`: anyone (public) can view this project
+- `project:child-456#parent@project:parent-123`: parent-child hierarchy link
+- `committee:abc#member@user:bob`: bob is a member of this committee
 
 ### Tuple-format rejection conditions
 

--- a/docs/fga-sync-contract.md
+++ b/docs/fga-sync-contract.md
@@ -1,0 +1,333 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# OpenFGA Access Control Contract (Authoritative)
+
+This is the **owner document** for the platform's FGA access sync envelope, generic
+FGA NATS subjects, tuple format, cache behavior, and access-check semantics. Other
+services link here rather than copy.
+
+The platform uses ReBAC (Relationship-Based Access Control) via OpenFGA. Permissions
+are stored as OpenFGA tuples and checked at query time by `lfx-v2-query-service` via
+this service (`lfx-v2-fga-sync`).
+
+## Generic Subjects (publishers should use these)
+
+| Subject | Purpose | Reply |
+| --- | --- | --- |
+| `lfx.fga-sync.update_access` | Create/update access tuples for a resource | `OK` on success if reply subject is provided |
+| `lfx.fga-sync.delete_access` | Delete all tuples for a resource (on delete) | `OK` on success if reply subject is provided |
+| `lfx.fga-sync.member_put` | Add a user to a resource with one or more relations | `OK` on success if reply subject is provided |
+| `lfx.fga-sync.member_remove` | Remove specific or all relations for a user | `OK` on success if reply subject is provided |
+| `lfx.access_check.request` | Batch authorization check (used by query-service) | text body |
+| `lfx.access_check.read_tuples` | Read all direct tuples for a user + object_type | JSON body |
+
+Handlers are generic: **publishers do not need fga-sync code changes when adding a
+new resource type that is defined in the OpenFGA model**. Use the generic
+envelope below.
+
+## Tuple Format
+
+```text
+{user_type}:{user_id}#{relation}@{object_type}:{object_id}
+```
+
+Examples:
+
+- `user:alice#writer@project:proj-123`: alice is a writer on this project
+- `user:*#viewer@project:proj-123`: anyone (public) can view this project
+- `project:parent-123#parent@project:child-456`: parent-child hierarchy link
+- `user:bob#member@committee:abc`: bob is a member of this committee
+
+### Tuple-format rejection conditions
+
+fga-sync rejects malformed envelopes before writing to OpenFGA, and the
+subscription loop logs the returned error with subject and queue context. Sync
+subjects only send `OK` after successful processing; they do not currently send a
+standardized error reply body. Agents debugging missing access should grep
+service logs first.
+
+| Condition | Behavior |
+| --- | --- |
+| `username` missing/empty on `member_put` or `member_remove` | Message rejected |
+| `uid` missing/empty on any sync operation | Message rejected |
+| `relations` empty on `member_put` | Message rejected |
+| `relations` empty on `member_remove` | Removes ALL relations for that user (intentional) |
+| `object_type` empty in envelope | Message rejected |
+| Unknown `operation` value | Message rejected |
+| `references` value with an empty `type` or empty `id` in `type:id` format | Message rejected |
+| Tuple rejected by OpenFGA with `validation_error` | Invalid tuple is logged, removed from the batch, and the remaining batch is retried |
+| Non-validation OpenFGA write/read error | Operation fails and is logged |
+
+## Access Message Envelope: `GenericFGAMessage`
+
+All generic sync subjects use this envelope:
+
+```go
+type GenericFGAMessage struct {
+    ObjectType string      `json:"object_type"` // e.g. "committee"
+    Operation  string      `json:"operation"`   // matches subject suffix
+    Data       interface{} `json:"data"`
+}
+```
+
+### `update_access` (create/update)
+
+```json
+{
+  "object_type": "committee",
+  "operation": "update_access",
+  "data": {
+    "uid": "resource-uuid",
+    "public": false,
+    "relations": {
+      "writer": ["alice"],
+      "auditor": ["bob"]
+    },
+    "references": {
+      "project": ["parent-project-uuid"]
+    },
+    "exclude_relations": ["participant"]
+  }
+}
+```
+
+- `relations` is a full sync: any relation key not included is removed.
+- `references` values can be bare UIDs (handler prepends the map key as the type
+  prefix, e.g. `"project": ["abc"]` → `project:abc`) or full `type:uid` strings.
+  Both are accepted.
+- `references.project` produces tuple `project:{project_uid}#project@committee:{committee_uid}`,
+  enabling permission inheritance from the parent project.
+- `exclude_relations` lets a publisher manage some relations separately (e.g. members
+  managed by a different subject). Those relations are left untouched.
+
+### `delete_access` (on resource delete)
+
+```json
+{
+  "object_type": "committee",
+  "operation": "delete_access",
+  "data": {"uid": "abc-123-uuid"}
+}
+```
+
+Purges **all** OpenFGA tuples for that object across all relations.
+
+### `member_put` / `member_remove`
+
+```go
+// Add member
+GenericFGAMessage{ObjectType: "committee", Operation: "member_put",
+    Data: map[string]interface{}{
+        "uid": committeeUID, "username": "alice", "relations": []string{"member"},
+        // optional: "mutually_exclusive_with": []string{"viewer"}
+    }}
+
+// Remove member (empty relations = remove all)
+GenericFGAMessage{ObjectType: "committee", Operation: "member_remove",
+    Data: map[string]interface{}{
+        "uid": committeeUID, "username": "alice", "relations": []string{},
+    }}
+```
+
+`member_put` is idempotent and supports `mutually_exclusive_with` for role transitions.
+See `docs/client-guide.md` for the full reference and additional examples.
+
+## Access Check Subjects (consumed by query-service)
+
+### `lfx.access_check.request`
+
+Multiple relationship checks, one per line; each formatted `object#relation@user`:
+
+```text
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#writer@user:456
+project:7cad5a8d-19d0-41a4-81a6-043453daf9ee#viewer@user:456
+```
+
+Reply is plain text, one line per check, tab-delimited `{request}\t{true|false}`.
+
+**Order is not guaranteed** (cached results may be returned first); callers must
+match on the request token, not by index.
+
+### `lfx.access_check.read_tuples`
+
+Returns all direct OpenFGA tuples for a given user and object type. Paginates internally.
+
+```json
+// Request
+{"user": "user:auth0|alice", "object_type": "project"}
+
+// Response success
+{"results": ["project:uuid1#writer@user:auth0|alice"]}
+
+// Response error
+{"error": "failed to read tuples"}
+```
+
+## OpenFGA Model Boundaries
+
+The authorization model lives in
+`lfx-v2-helm/charts/lfx-platform/templates/openfga/model.yaml`. fga-sync does not
+own model definitions; it only writes tuples that the model allows.
+
+| Concern | Owner |
+| --- | --- |
+| Object types, relations, computed relations, hierarchical relations | `lfx-v2-helm` (model.yaml) |
+| Generic sync handlers and tuple I/O | `lfx-v2-fga-sync` (this repo) |
+| Per-resource emission rules (what relations a service sends) | Each resource service's `docs/fga-contract.md` |
+| Heimdall `openfga_check` rules per HTTP verb/path | Each service's Helm chart `ruleset.yaml` |
+| Runtime access checks (`lfx.access_check.request`) | `lfx-v2-fga-sync` answers them; `lfx-v2-access-check` exposes an HTTP wrapper |
+
+### Permission inheritance pattern in the model
+
+```text
+type project
+  relations
+    define parent: [project]
+    define writer: [user] or writer from parent
+    define auditor: [user] or writer or auditor from parent
+    define viewer: [user:*] or auditor or auditor from parent
+
+type committee
+  relations
+    define project: [project]
+    define writer: writer from project
+    define auditor: auditor from project
+    define viewer: [user:*] or auditor from project
+```
+
+- A `writer` on a parent project is automatically a `writer` on all child projects.
+- A `writer` on a project is automatically a `writer` on all its committees.
+- Public resources use `user:*` (wildcard): the query-service bypasses the FGA check
+  entirely and filters OpenSearch by `public: true` instead.
+
+### Model evolution policy
+
+- **Adding a new object type or relation**: edit `model.yaml` in `lfx-v2-helm` AND
+  bump the model version (Argo redeploys the new model). Existing tuples remain valid
+  for relations that still exist.
+- **Renaming a relation**: breaking. All existing tuples for that relation become
+  unreachable; coordinate a migration.
+- **Removing an object type**: breaking. Tuples become orphaned. Delete via a
+  `delete_access` pass before removing the type from the model.
+- **Heimdall rules** must be updated in the same PR cycle as a new model object type.
+  Without an `openfga_check` rule on the routes, the gateway will not enforce.
+
+## Cache Behavior
+
+fga-sync caches access check results in a NATS JetStream KV bucket (`fga-sync-cache`).
+
+| Aspect | Detail |
+| --- | --- |
+| Cache key | Base32-encoded relation tuple `rel.{encoded-relation}` |
+| Cache value | Raw text boolean: `true` or `false`; freshness uses the NATS KV entry timestamp |
+| Invalidation | A single `inv` timestamp key, every successful OpenFGA write bumps it, making all older cached entries stale |
+| Stale handling | Stale hits are counted separately at `/debug/vars` and then rechecked against OpenFGA |
+| Fallback | Cache miss falls through to a direct OpenFGA query |
+
+### Debugging cache behavior
+
+- Counters at `/debug/vars`: `cache_hits`, `cache_misses`, `cache_stale_hits`.
+- If access checks return wrong/old results, look for `"cache invalidation failed"`
+  in fga-sync logs. The `inv` key may have failed to bump.
+- Manually invalidate by writing any value to the `inv` key in the `fga-sync-cache`
+  bucket; this forces every cached entry to be treated as stale on next read.
+- A successful any-type OpenFGA write re-invalidates. When in doubt, trigger any
+  `update_access` on any resource and stale entries clear globally.
+
+## Publishing Access Messages (Go Code Example)
+
+```go
+msg := GenericFGAMessage{
+    ObjectType: "sponsorship",
+    Operation:  "update_access",
+    Data: map[string]interface{}{
+        "uid":    resource.UID,
+        "public": resource.Public,
+        "relations": map[string][]string{
+            "writer": {"alice"},
+        },
+        "references": map[string][]string{
+            "project": {resource.ProjectUID},
+        },
+    },
+}
+nc.Publish("lfx.fga-sync.update_access", payload)
+```
+
+## Debugging Access Issues
+
+When a user can't see a resource they should have access to, there are two root
+causes. Check them in this order:
+
+### 1. Indexing problem: document missing or stale in OpenSearch
+
+Query OpenSearch directly:
+
+```bash
+curl "$OPENSEARCH_URL/lfx-resources/_search" -H 'Content-Type: application/json' -d '{
+  "query": {"bool": {"must": [
+    {"term": {"object_type": "committee"}},
+    {"term": {"object_id": "<uid>"}},
+    {"term": {"latest": true}}
+  ]}},
+  "_source": ["access_check_object", "access_check_relation", "public"]
+}'
+```
+
+- No results → index message was never published or indexer failed to process it.
+- Results but `access_check_object` empty → `IndexingConfig` was missing or malformed.
+  See `lfx-v2-indexer-service/docs/indexer-contract.md`.
+- Fix: trigger a no-op update on the resource to republish both NATS messages.
+
+### 2. Permissions problem: FGA tuple missing or wrong
+
+Check existing tuples:
+
+```bash
+fga tuple read --object committee:<uid>
+```
+
+Common causes:
+
+- `update_access` NATS message never published (check resource service logs for
+  publish errors).
+- Wrong `references` in the access message (wrong parent project UID).
+- User's LFID in the JWT doesn't match the username stored in the tuple.
+- Member payload was missing `username`. fga-sync rejects `member_put` and
+  `member_remove` when username is empty.
+- Cache is stale. Any successful OpenFGA write re-invalidates, or manually write to
+  the `inv` KV key.
+
+### Auditing recent tuple changes
+
+For a quick view of recent OpenFGA writes/deletes across the store, run the
+`list-tuple-changes` CLI from this repo:
+
+```bash
+go run ./scripts/audit/list-tuple-changes -since 1h -type committee
+```
+
+See `scripts/audit/list-tuple-changes/README.md` for flags (`-since`, `-type`,
+`-all-pages`) and example output.
+
+## FGA Contract: Per-Service Documentation
+
+Services that follow the FGA contract pattern keep a `docs/fga-contract.md` at the
+root of their repo. This is the authoritative reference for that service's object
+types, message schemas, operations, relations, and trigger conditions, derived
+directly from the source code.
+
+**Read this before writing or modifying FGA message construction for an existing
+service.** It tells you what subjects are used, what payload shape is expected, and
+what conditions cause messages to be rejected or skipped by OpenFGA validation.
+
+**Update it in the same PR as any FGA messaging change.** The doc must stay in sync
+with the code.
+
+The [committee-service](https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/fga-contract.md)
+is the reference implementation of this pattern. Use it as a template when adding a
+contract to a new service.
+
+For a full index of all services and their FGA object types, see
+`docs/fga-protected-types.md`.


### PR DESCRIPTION
## Summary

Part of the LFX developer-AI **fan-out** ([LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)): repo-specific AI guidance moves out of the central `lfx-skills` plugin and into each owning repo, beside the code it describes. This PR lands this repo's share of that work.

> ## 📖 Read these first (they explain this PR)
>
> This is one of ~15 coordinated fan-out PRs. **Before reviewing, please read the three short docs that explain the whole change** — they are the source of truth for the model and for what landed where:
>
> | Doc | What it gives you |
> |---|---|
> | 👉 **[Fan-out architecture](https://docs.google.com/document/d/10eZy8n5xgU7LratcntjkUjGSZmuHpO0xUkskJbJPkfc/edit?usp=sharing)** | The end-to-end model and the why behind it: the central-vs-repo split, the review lifecycle, and the per-repo tradeoffs. **Start here.** |
> | 👉 **[Fan-out owner guidance](https://docs.google.com/document/d/15MPhvRh4Ifxr7VZnIiD2xxoWy_mjv1naeKW4IQLa3iU/edit?usp=sharing)** | The new ownership model, central-vs-repo boundaries, and the review-lifecycle expectations. |
> | 👉 **[Rollout inventory](https://docs.google.com/document/d/1kqhRjzDz0_7a4z4nRZMyD-yQWL6ZEZC_dztz8yhb4K0/edit?usp=sharing)** | Exactly what moved out of central and what landed in each repo — find this repo's section for the full scope. |
>
> Tracking epic: **[LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)**.

## Why — the new architecture

**Central finds the right owner and explains the shared platform; each repo explains itself.** The central `lfx-skills` plugin keeps only genuinely-central surfaces: cross-repo routing, platform architecture, shared integration guidance, global workflows, and reviewer-agent distribution. Repo-specific implementation truth — conventions, generated-code boundaries, endpoint workflows, contracts, and chart defaults — now lives in the owning repo, where it changes together with the contracts, tests, and charts it describes.

This fixes the drift problem a central rulebook creates: it either grows until it contains repo-specific exceptions for every service, or stays short and goes stale. Where a repo has a review lifecycle, its repo-specific reviewer agents are packaged centrally (so they're available by name in any Claude runtime) but read **evidence this repo owns** — its `CLAUDE.md`, skills, rules, contracts, checklists, and review KB.

## Changes in this repo

This repo owns the generic FGA tuple-emission and access-check contracts that many other repos consume, so doc accuracy is high-value.

- Repo-local skills: `fga-sync-dev` (single-package layout, slog, NATS QueueSubscribe + JetStream KV cache, generic resource-agnostic handlers, tests) and `fga-tuple-emission` (the publisher-side workflow).
- Owned docs: `docs/fga-sync-contract.md` (generic envelope, subjects, tuple format, cache behavior, access-check semantics), `docs/fga-protected-types.md`, `docs/client-guide.md`, `docs/fga-catalog.md` — the protected-types inventory + catalog cover all current publishers, including member-service (`b2b_org` / `project_membership`).
- `CLAUDE.md` routes platform/topology questions to the central skills and keeps the FGA contract repo-owned.

> This branch is current with `main`.

### Kept current with `main` (2026-06-11)

This branch was re-merged with the latest `main` and the guidance re-audited against the current code. Small accuracy fixes landed: the real `NATS_URL` default, the actual mock surface (`IFgaClient`), the structured-log field names, and a softened catalog claim about per-type prefix constants.

## Reference links

- **Jira epic:** [LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)
- **Owner guidance** — steady-state ownership + review lifecycle: [Owner guidance (Google Doc)](https://docs.google.com/document/d/15MPhvRh4Ifxr7VZnIiD2xxoWy_mjv1naeKW4IQLa3iU/edit?usp=sharing)
- **Rollout inventory** — per-repo "what changed": [Rollout inventory (Google Doc)](https://docs.google.com/document/d/1kqhRjzDz0_7a4z4nRZMyD-yQWL6ZEZC_dztz8yhb4K0/edit?usp=sharing)
- **Fan-out architecture** — the model and the why: [Fan-out architecture (Google Doc)](https://docs.google.com/document/d/10eZy8n5xgU7LratcntjkUjGSZmuHpO0xUkskJbJPkfc/edit?usp=sharing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LFXV2-2015]: https://linuxfoundation.atlassian.net/browse/LFXV2-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2015]: https://linuxfoundation.atlassian.net/browse/LFXV2-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
