### PR TITLE
[LFXV2-1743] feat(otel): add NATS span instrumentation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -120,7 +120,8 @@
         "traceparent",
         "tracestate",
         "INTERNALERRORCODE",
-        "noctx"
+        "noctx",
+        "natsgo"
       ]
     },
     {

--- a/handler.go
+++ b/handler.go
@@ -40,6 +40,7 @@ type INatsMsg interface {
 	Respond(data []byte) error
 	Data() []byte
 	Subject() string
+	Header() nats.Header
 }
 
 // NatsMsg is a wrapper around [nats.Msg] that implements [INatsMsg].
@@ -67,13 +68,18 @@ func (m *NatsMsg) Subject() string {
 	return m.Msg.Subject
 }
 
+// Header implements [INatsMsg.Header].
+func (m *NatsMsg) Header() nats.Header {
+	return m.Msg.Header
+}
+
 // processStandardAccessUpdate handles the default access control update logic
 func (h *HandlerService) processStandardAccessUpdate(
+	ctx context.Context,
 	message INatsMsg,
 	obj *standardAccessStub,
 	excludeRelations ...string,
 ) error {
-	ctx := context.Background()
 
 	logger.With("message", string(message.Data())).InfoContext(
 		ctx,

--- a/handler_access.go
+++ b/handler_access.go
@@ -9,8 +9,7 @@ import (
 )
 
 // accessCheckHandler handles access check requests from the NATS server.
-func (h *HandlerService) accessCheckHandler(message INatsMsg) error {
-	ctx := context.Background()
+func (h *HandlerService) accessCheckHandler(ctx context.Context, message INatsMsg) error {
 
 	var response []byte
 	var err error

--- a/handler_access_test.go
+++ b/handler_access_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"strings"
@@ -234,7 +235,7 @@ func TestAccessCheckHandler(t *testing.T) {
 
 			// Test that the function doesn't panic
 			assert.NotPanics(t, func() {
-				err := handlerService.accessCheckHandler(msg)
+				err := handlerService.accessCheckHandler(context.Background(), msg)
 				if tt.expectedError {
 					assert.Error(t, err)
 				} else {
@@ -661,7 +662,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 
 			// Test that the function doesn't panic
 			assert.NotPanics(t, func() {
-				err := handlerService.processStandardAccessUpdate(msg, tt.obj)
+				err := handlerService.processStandardAccessUpdate(context.Background(), msg, tt.obj)
 				if tt.expectedError {
 					assert.Error(t, err)
 				} else {

--- a/handler_generic.go
+++ b/handler_generic.go
@@ -33,8 +33,7 @@ import (
 //	    "exclude_relations": ["participant"]
 //	  }
 //	}
-func (h *HandlerService) genericUpdateAccessHandler(message INatsMsg) error {
-	ctx := context.Background()
+func (h *HandlerService) genericUpdateAccessHandler(ctx context.Context, message INatsMsg) error {
 
 	// Parse generic message
 	genericMsg := new(fgatypes.GenericFGAMessage)
@@ -75,7 +74,7 @@ func (h *HandlerService) genericUpdateAccessHandler(message INatsMsg) error {
 	}
 
 	// Use existing generic handler
-	return h.processStandardAccessUpdate(message, stub, data.ExcludeRelations...)
+	return h.processStandardAccessUpdate(ctx, message, stub, data.ExcludeRelations...)
 }
 
 // genericDeleteAccessHandler handles universal delete_access operations.
@@ -92,8 +91,7 @@ func (h *HandlerService) genericUpdateAccessHandler(message INatsMsg) error {
 //	    "uid": "committee-123"
 //	  }
 //	}
-func (h *HandlerService) genericDeleteAccessHandler(message INatsMsg) error {
-	ctx := context.Background()
+func (h *HandlerService) genericDeleteAccessHandler(ctx context.Context, message INatsMsg) error {
 
 	// Parse generic message
 	genericMsg := new(fgatypes.GenericFGAMessage)
@@ -198,8 +196,7 @@ func (h *HandlerService) genericDeleteAccessHandler(message INatsMsg) error {
 //	    "mutually_exclusive_with": ["participant", "host"]
 //	  }
 //	}
-func (h *HandlerService) genericMemberPutHandler(message INatsMsg) error {
-	ctx := context.Background()
+func (h *HandlerService) genericMemberPutHandler(ctx context.Context, message INatsMsg) error {
 
 	// Parse and validate message
 	genericMsg, data, err := h.parseAndValidateMemberPutMessage(ctx, message)
@@ -425,8 +422,7 @@ func (h *HandlerService) sendReplyIfNeeded(ctx context.Context, message INatsMsg
 //	    "relations": []
 //	  }
 //	}
-func (h *HandlerService) genericMemberRemoveHandler(message INatsMsg) error {
-	ctx := context.Background()
+func (h *HandlerService) genericMemberRemoveHandler(ctx context.Context, message INatsMsg) error {
 
 	// Parse generic message
 	genericMsg := new(fgatypes.GenericFGAMessage)

--- a/handler_read_tuples.go
+++ b/handler_read_tuples.go
@@ -20,8 +20,8 @@ const readTuplesTimeout = 10 * time.Second
 // readTuplesHandler handles requests to read a user's direct OpenFGA tuples for
 // a given object type. It responds with a JSON-encoded ReadTuplesResponse
 // containing tuple-strings in object#relation@user format.
-func (h *HandlerService) readTuplesHandler(message INatsMsg) error {
-	ctx, cancel := context.WithTimeout(context.Background(), readTuplesTimeout)
+func (h *HandlerService) readTuplesHandler(ctx context.Context, message INatsMsg) error {
+	ctx, cancel := context.WithTimeout(ctx, readTuplesTimeout)
 	defer cancel()
 
 	// Unmarshal the JSON request payload.

--- a/handler_read_tuples_test.go
+++ b/handler_read_tuples_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -279,7 +280,7 @@ func TestReadTuplesHandler(t *testing.T) {
 			tt.mockSetup(service.fgaService.client.(*MockFgaClient), msg)
 
 			assert.NotPanics(t, func() {
-				err := service.readTuplesHandler(msg)
+				err := service.readTuplesHandler(context.Background(), msg)
 				if tt.expectError {
 					assert.Error(t, err)
 				} else {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,10 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	slogotel "github.com/remychantenay/slog-otel"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -312,7 +316,7 @@ func createHTTPHandlers() {
 }
 
 // HandlerFunc defines a message handler function type.
-type HandlerFunc func(INatsMsg) error
+type HandlerFunc func(context.Context, INatsMsg) error
 
 // subscriptionConfig defines a NATS subscription configuration.
 type subscriptionConfig struct {
@@ -324,7 +328,19 @@ type subscriptionConfig struct {
 // subscribeToSubject subscribes to a single NATS subject with error handling and logging.
 func subscribeToSubject(subject, description, queue string, handler HandlerFunc) error {
 	if _, err := natsConn.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
-		if errHandler := handler(&NatsMsg{msg}); errHandler != nil {
+		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
+		msgCtx, span := tracer.Start(msgCtx, "nats.process",
+			trace.WithSpanKind(trace.SpanKindConsumer),
+			trace.WithAttributes(
+				attribute.String("messaging.system", "nats"),
+				attribute.String("messaging.destination", subject),
+				attribute.String("messaging.operation", "process"),
+			),
+		)
+		defer span.End()
+		if errHandler := handler(msgCtx, &NatsMsg{msg}); errHandler != nil {
+			span.RecordError(errHandler)
+			span.SetStatus(codes.Error, errHandler.Error())
 			logger.Error("error handling "+description+" request",
 				errKey, errHandler,
 				"subject", subject,

--- a/main.go
+++ b/main.go
@@ -334,7 +334,7 @@ func subscribeToSubject(subject, description, queue string, handler HandlerFunc)
 			hdr = msg.Header
 		}
 		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(hdr))
-		msgCtx, span := tracer.Start(msgCtx, subject + " process",
+		msgCtx, span := tracer.Start(msgCtx, subject+" process",
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "nats"),

--- a/main.go
+++ b/main.go
@@ -333,7 +333,7 @@ func subscribeToSubject(subject, description, queue string, handler HandlerFunc)
 			msg.Header = make(nats.Header)
 		}
 		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
-		msgCtx, span := tracer.Start(msgCtx, "nats.process",
+		msgCtx, span := tracer.Start(msgCtx, subject+" process",
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "nats"),

--- a/main.go
+++ b/main.go
@@ -328,6 +328,10 @@ type subscriptionConfig struct {
 // subscribeToSubject subscribes to a single NATS subject with error handling and logging.
 func subscribeToSubject(subject, description, queue string, handler HandlerFunc) error {
 	if _, err := natsConn.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
+		// Initialize message header if nil to prevent panic when injecting trace context
+		if msg.Header == nil {
+			msg.Header = make(nats.Header)
+		}
 		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
 		msgCtx, span := tracer.Start(msgCtx, "nats.process",
 			trace.WithSpanKind(trace.SpanKindConsumer),

--- a/main.go
+++ b/main.go
@@ -328,16 +328,17 @@ type subscriptionConfig struct {
 // subscribeToSubject subscribes to a single NATS subject with error handling and logging.
 func subscribeToSubject(subject, description, queue string, handler HandlerFunc) error {
 	if _, err := natsConn.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
-		// Initialize message header if nil to prevent panic when injecting trace context
-		if msg.Header == nil {
-			msg.Header = make(nats.Header)
+		// Extract trace context from message headers, handling nil header gracefully
+		var hdr nats.Header
+		if msg.Header != nil {
+			hdr = msg.Header
 		}
-		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
-		msgCtx, span := tracer.Start(msgCtx, subject+" process",
+		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(hdr))
+		msgCtx, span := tracer.Start(msgCtx, subject + " process",
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "nats"),
-				attribute.String("messaging.destination", subject),
+				attribute.String("messaging.destination.name", subject),
 				attribute.String("messaging.operation", "process"),
 			),
 		)

--- a/main.go
+++ b/main.go
@@ -334,12 +334,12 @@ func subscribeToSubject(subject, description, queue string, handler HandlerFunc)
 			hdr = msg.Header
 		}
 		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(hdr))
-		msgCtx, span := tracer.Start(msgCtx, subject+" process",
+		msgCtx, span := tracer.Start(msgCtx, "nats.process",
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
 				attribute.String("messaging.system", "nats"),
 				attribute.String("messaging.destination.name", subject),
-				attribute.String("messaging.operation", "process"),
+				attribute.String("messaging.operation.type", "process"),
 			),
 		)
 		defer span.End()

--- a/mock.go
+++ b/mock.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	nats "github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	openfga "github.com/openfga/go-sdk"
 	"github.com/stretchr/testify/mock"
@@ -90,6 +91,11 @@ func (m *MockNatsMsg) Data() []byte {
 // Subject implements the INatsMsg interface
 func (m *MockNatsMsg) Subject() string {
 	return m.subject
+}
+
+// Header implements the INatsMsg interface
+func (m *MockNatsMsg) Header() nats.Header {
+	return nats.Header{}
 }
 
 // CreateMockNatsMsg creates a mock NATS message that can be used in tests

--- a/pkg/utils/otel.go
+++ b/pkg/utils/otel.go
@@ -48,6 +48,9 @@ const (
 	otelSamplerParentBasedAlwaysOn     = "parentbased_always_on"
 	otelSamplerParentBasedAlwaysOff    = "parentbased_always_off"
 	otelSamplerParentBasedTraceIDRatio = "parentbased_traceidratio"
+
+	// defaultPropagators is the default value for OTEL_PROPAGATORS.
+	defaultPropagators = "tracecontext,baggage"
 )
 
 // OTelConfig holds OpenTelemetry configuration options.
@@ -128,7 +131,7 @@ func OTelConfigFromEnv() OTelConfig {
 
 	propagators := os.Getenv("OTEL_PROPAGATORS")
 	if propagators == "" {
-		propagators = "tracecontext,baggage"
+		propagators = defaultPropagators
 	}
 
 	tracesSampler := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER"))

--- a/tracing.go
+++ b/tracing.go
@@ -23,6 +23,11 @@ func (c natsHeaderCarrier) Get(key string) string {
 }
 
 func (c natsHeaderCarrier) Set(key, value string) {
+	if c == nil {
+		// Cannot set on nil carrier; silently drop the value.
+		// This matches the behavior of Extract, which safely reads from nil maps.
+		return
+	}
 	c[key] = []string{value}
 }
 

--- a/tracing.go
+++ b/tracing.go
@@ -22,7 +22,7 @@ func (c natsHeaderCarrier) Get(key string) string {
 	return vals[0]
 }
 
-func (c natsHeaderCarrier) Set(key string, value string) {
+func (c natsHeaderCarrier) Set(key, value string) {
 	c[key] = []string{value}
 }
 

--- a/tracing.go
+++ b/tracing.go
@@ -1,0 +1,37 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	natsgo "github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-fga-sync")
+
+// natsHeaderCarrier adapts nats.Header to propagation.TextMapCarrier.
+type natsHeaderCarrier natsgo.Header
+
+func (c natsHeaderCarrier) Get(key string) string {
+	vals := c[key]
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+func (c natsHeaderCarrier) Set(key string, value string) {
+	c[key] = []string{value}
+}
+
+func (c natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+var _ propagation.TextMapCarrier = natsHeaderCarrier{}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -1,0 +1,188 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	natsgo "github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func TestNatsHeaderCarrier_Get(t *testing.T) {
+	tests := []struct {
+		name   string
+		header natsgo.Header
+		key    string
+		want   string
+	}{
+		{
+			name:   "existing key",
+			header: natsgo.Header{"traceparent": []string{"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}},
+			key:    "traceparent",
+			want:   "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		},
+		{
+			name:   "missing key",
+			header: natsgo.Header{},
+			key:    "traceparent",
+			want:   "",
+		},
+		{
+			name:   "nil header",
+			header: nil,
+			key:    "traceparent",
+			want:   "",
+		},
+		{
+			name:   "multi-value key returns first",
+			header: natsgo.Header{"key": []string{"value1", "value2"}},
+			key:    "key",
+			want:   "value1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := natsHeaderCarrier(tt.header)
+			got := c.Get(tt.key)
+			if got != tt.want {
+				t.Errorf("Get(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNatsHeaderCarrier_Set(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     natsgo.Header
+		key        string
+		value      string
+		wantPanic  bool
+		wantHeader natsgo.Header
+	}{
+		{
+			name:       "set on non-nil header",
+			header:     natsgo.Header{},
+			key:        "traceparent",
+			value:      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+			wantPanic:  false,
+			wantHeader: natsgo.Header{"traceparent": []string{"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}},
+		},
+		{
+			name:       "set on nil header does not panic",
+			header:     nil,
+			key:        "traceparent",
+			value:      "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+			wantPanic:  false,
+			wantHeader: nil,
+		},
+		{
+			name:       "overwrite existing key",
+			header:     natsgo.Header{"key": []string{"old"}},
+			key:        "key",
+			value:      "new",
+			wantPanic:  false,
+			wantHeader: natsgo.Header{"key": []string{"new"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := natsHeaderCarrier(tt.header)
+			defer func() {
+				r := recover()
+				if tt.wantPanic && r == nil {
+					t.Error("expected panic, got none")
+				}
+				if !tt.wantPanic && r != nil {
+					t.Errorf("unexpected panic: %v", r)
+				}
+			}()
+			c.Set(tt.key, tt.value)
+			// Only check the header if we expect it to be non-nil and not panicked
+			if !tt.wantPanic && tt.header != nil {
+				if val := tt.header[tt.key]; len(val) > 0 && val[0] != tt.value {
+					t.Errorf("Set(%q, %q) resulted in %q", tt.key, tt.value, val[0])
+				}
+			}
+		})
+	}
+}
+
+func TestNatsHeaderCarrier_Keys(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    natsgo.Header
+		wantLen   int
+		wantPanic bool
+	}{
+		{
+			name:      "empty header",
+			header:    natsgo.Header{},
+			wantLen:   0,
+			wantPanic: false,
+		},
+		{
+			name:      "nil header",
+			header:    nil,
+			wantLen:   0,
+			wantPanic: false,
+		},
+		{
+			name:      "header with keys",
+			header:    natsgo.Header{"key1": []string{"val1"}, "key2": []string{"val2"}},
+			wantLen:   2,
+			wantPanic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tt.wantPanic && r == nil {
+					t.Error("expected panic, got none")
+				}
+				if !tt.wantPanic && r != nil {
+					t.Errorf("unexpected panic: %v", r)
+				}
+			}()
+			c := natsHeaderCarrier(tt.header)
+			keys := c.Keys()
+			if len(keys) != tt.wantLen {
+				t.Errorf("Keys() returned %d keys, want %d", len(keys), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestNatsHeaderCarrier_TextMapCarrier(t *testing.T) {
+	// Verify that natsHeaderCarrier implements propagation.TextMapCarrier
+	var _ propagation.TextMapCarrier = natsHeaderCarrier{}
+
+	// Test that a propagator can use it
+	header := natsgo.Header{
+		"traceparent": []string{"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"},
+	}
+	c := natsHeaderCarrier(header)
+
+	// Verify interface methods work
+	if c.Get("traceparent") == "" {
+		t.Error("Get should return the traceparent value")
+	}
+
+	// Verify Keys works
+	keys := c.Keys()
+	if len(keys) == 0 {
+		t.Error("Keys should return at least one key")
+	}
+
+	// Verify Set doesn't panic on non-nil carrier
+	c.Set("tracestate", "vendor=value")
+	if c.Get("tracestate") != "vendor=value" {
+		t.Error("Set and Get should work together")
+	}
+}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	natsgo "github.com/nats-io/nats.go"
@@ -102,10 +103,9 @@ func TestNatsHeaderCarrier_Set(t *testing.T) {
 				}
 			}()
 			c.Set(tt.key, tt.value)
-			// Only check the header if we expect it to be non-nil and not panicked
-			if !tt.wantPanic && tt.header != nil {
-				if val := tt.header[tt.key]; len(val) > 0 && val[0] != tt.value {
-					t.Errorf("Set(%q, %q) resulted in %q", tt.key, tt.value, val[0])
+			if !tt.wantPanic {
+				if !reflect.DeepEqual(tt.header, tt.wantHeader) {
+					t.Errorf("Set(%q, %q) header = %#v, want %#v", tt.key, tt.value, tt.header, tt.wantHeader)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- Add `tracing.go` with `natsHeaderCarrier` (OTel TextMapCarrier adaptor) and package-level `tracer`
- Extract trace context from incoming NATS message headers in `subscribeToSubject` before dispatching to handlers
- Start Consumer spans with subject-specific names and messaging semantic attributes
- Change `HandlerFunc` signature to `func(context.Context, INatsMsg) error` so extracted trace context propagates to all handlers and downstream OTel-instrumented calls (FGA HTTP client)
- Replace `context.Background()` in all 6 handler functions with the extracted context
- Add `Header() nats.Header` to `INatsMsg` interface and implementations

## Test plan

- [ ] `make build` passes
- [ ] `go test ./...` passes
- [ ] Trace spans appear in Datadog APM for NATS-triggered operations