### PR TITLE
feat: add topologySpreadConstraints to Helm chart

### DIFF
--- a/charts/lfx-v2-fga-sync/templates/deployment.yaml
+++ b/charts/lfx-v2-fga-sync/templates/deployment.yaml
@@ -134,3 +134,7 @@ spec:
             periodSeconds: 1
           resources:
             {{toYaml .Values.application.resources | nindent 12}}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -36,6 +36,16 @@ podDisruptionBudget:
   # minAvailable: 1
   # maxUnavailable: 1
 
+# topologySpreadConstraints controls how pods are spread across nodes/zones.
+# Empty by default (no constraints). Example:
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: DoNotSchedule
+#     labelSelector:
+#       matchLabels:
+#         app: lfx-v2-fga-sync
+topologySpreadConstraints: []
+
 # nats is the configuration for the NATS server
 nats:
   # url is the URL of the NATS server


### PR DESCRIPTION
## Summary

- Add `topologySpreadConstraints: []` to `values.yaml` (empty default, no-op unless overridden)
- Add conditional `{{- with .Values.topologySpreadConstraints }}` block to `deployment.yaml` at the pod spec level

## Test plan

- [x] `helm lint` passes with no errors
- [x] `helm template` with empty default produces no `topologySpreadConstraints` block
- [x] `helm template` with constraints set renders correctly at pod spec level

## Context

Part of LFXV2-1167: add topology spread constraints to all LFX v2 services so pods spread across nodes and availability zones, preventing a single node drain from taking out all replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)