### PR TITLE
feat: record HTTP client errors on OTel spans

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -122,7 +122,9 @@
         "tracestate",
         "INTERNALERRORCODE",
         "noctx",
-        "natsgo"
+        "natsgo",
+        "tracetest",
+        "sdktrace"
       ]
     },
     {

--- a/fga.go
+++ b/fga.go
@@ -21,6 +21,8 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	openfga "github.com/openfga/go-sdk"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	. "github.com/openfga/go-sdk/client"
 )
@@ -126,6 +128,7 @@ func (s FgaService) ReadObjectTuples(ctx context.Context, object string) ([]open
 	for {
 		resp, err := s.client.Read(ctx, req, options)
 		if err != nil {
+			recordSpanError(ctx, err)
 			return nil, err
 		}
 		tuples = append(tuples, resp.Tuples...)
@@ -151,6 +154,7 @@ func (s FgaService) ReadUserTuples(ctx context.Context, user, objectType string)
 	for {
 		resp, err := s.client.Read(ctx, req, options)
 		if err != nil {
+			recordSpanError(ctx, err)
 			return nil, err
 		}
 		tuples = append(tuples, resp.Tuples...)
@@ -179,6 +183,7 @@ func (s FgaService) ListObjectsByUserAndRelation(
 
 	resp, err := s.client.ListObjects(ctx, body, options)
 	if err != nil {
+		recordSpanError(ctx, err)
 		return nil, err
 	}
 
@@ -456,6 +461,7 @@ func (s FgaService) writeAndDeleteTuplesBatch(
 		if err != nil {
 			tupleStr, ok := extractInvalidTuple(err)
 			if !ok {
+				recordSpanError(ctx, err)
 				return err
 			}
 
@@ -465,6 +471,7 @@ func (s FgaService) writeAndDeleteTuplesBatch(
 				deletes, removed = removeInvalidDeleteTuple(deletes, tupleStr)
 			}
 			if !removed {
+				recordSpanError(ctx, err)
 				return err
 			}
 
@@ -497,6 +504,32 @@ func (s FgaService) writeAndDeleteTuplesBatch(
 	).InfoContext(ctx, "wrote and deleted tuples")
 
 	return nil
+}
+
+// fgaStatusCoder is implemented by all OpenFGA SDK API error types. It exposes
+// the HTTP response status code so callers can distinguish client (4xx) from
+// server (5xx) failures without importing concrete SDK error types.
+type fgaStatusCoder interface {
+	ResponseStatusCode() int
+}
+
+// fgaIs4xx returns true when err is an OpenFGA SDK API error with a 4xx HTTP
+// status code. These represent expected client-side conditions (bad request,
+// auth, not found) and must not be recorded as span errors.
+func fgaIs4xx(err error) bool {
+	var sc fgaStatusCoder
+	return errors.As(err, &sc) && sc.ResponseStatusCode() >= 400 && sc.ResponseStatusCode() < 500
+}
+
+// recordSpanError records err on the active span and marks it errored,
+// unless err represents an OpenFGA 4xx (expected client-side) condition.
+func recordSpanError(ctx context.Context, err error) {
+	if fgaIs4xx(err) {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
 }
 
 // extractInvalidTuple extracts the tuple string from an OpenFGA validation error.
@@ -801,6 +834,7 @@ func (s FgaService) CheckRelationships(ctx context.Context, tuples []ClientCheck
 	}
 	batchResp, err := s.client.BatchCheck(ctx, batchCheckRequest)
 	if err != nil {
+		recordSpanError(ctx, err)
 		return nil, err
 	}
 

--- a/fga_otel_test.go
+++ b/fga_otel_test.go
@@ -1,0 +1,254 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	openfga "github.com/openfga/go-sdk"
+	. "github.com/openfga/go-sdk/client"
+	"github.com/stretchr/testify/mock"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// fakeStatusErr is a test error that implements fgaStatusCoder, allowing tests
+// to simulate OpenFGA SDK errors with a specific HTTP status code.
+type fakeStatusErr struct{ code int }
+
+func (e fakeStatusErr) Error() string           { return fmt.Sprintf("HTTP %d", e.code) }
+func (e fakeStatusErr) ResponseStatusCode() int { return e.code }
+
+func newOtelTracer(t *testing.T) (trace.Tracer, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp.Tracer("test"), sr
+}
+
+func hasException(spans []sdktrace.ReadOnlySpan) bool {
+	for _, s := range spans {
+		for _, e := range s.Events() {
+			if e.Name == "exception" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasErrorStatus(spans []sdktrace.ReadOnlySpan) bool {
+	for _, s := range spans {
+		if s.Status().Code == codes.Error {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFgaService_RecordsErrorOnSpan verifies that each FgaService method calls
+// span.RecordError and span.SetStatus(codes.Error) when the underlying FGA
+// client returns a non-4xx error, and that 4xx errors are not recorded on the
+// span (they represent expected client-side conditions, not server failures).
+func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
+	tests := []struct {
+		name     string
+		wantSpan bool // true = expect exception event + error status on span
+		setup    func() FgaService
+		run      func(ctx context.Context, svc FgaService) error
+	}{
+		// 5xx / generic errors — span must be marked as errored.
+		{
+			name:     "ReadObjectTuples/5xx",
+			wantSpan: true,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("Read", mock.Anything, mock.Anything, mock.Anything).
+					Return((*ClientReadResponse)(nil), errors.New("fga read error"))
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.ReadObjectTuples(ctx, "project:123")
+				return err
+			},
+		},
+		{
+			name:     "ReadUserTuples/5xx",
+			wantSpan: true,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("Read", mock.Anything, mock.Anything, mock.Anything).
+					Return((*ClientReadResponse)(nil), errors.New("fga read error"))
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.ReadUserTuples(ctx, "user:alice", "project")
+				return err
+			},
+		},
+		{
+			name:     "ListObjectsByUserAndRelation/5xx",
+			wantSpan: true,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).
+					Return((*ClientListObjectsResponse)(nil), errors.New("fga list error"))
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.ListObjectsByUserAndRelation(ctx, "project", "writer", "user:alice")
+				return err
+			},
+		},
+		{
+			name:     "WriteAndDeleteTuples/5xx",
+			wantSpan: true,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				// Return a non-validation error so the retry path is not taken.
+				mc.On("Write", mock.Anything, mock.Anything).
+					Return((*ClientWriteResponse)(nil), errors.New("fga write error"))
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				return svc.WriteAndDeleteTuples(ctx,
+					[]ClientTupleKey{{User: "user:alice", Relation: "writer", Object: "project:123"}},
+					nil,
+				)
+			},
+		},
+		{
+			name:     "CheckRelationships/5xx",
+			wantSpan: true,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("BatchCheck", mock.Anything, mock.Anything).
+					Return((*openfga.BatchCheckResponse)(nil), errors.New("fga batch check error"))
+				mockKV := new(MockNatsKeyValue)
+				mockKV.On("Get", mock.Anything, "inv").Return(nil, jetstream.ErrKeyNotFound)
+				return FgaService{client: mc, cacheBucket: mockKV}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.CheckRelationships(ctx, []ClientCheckRequest{
+					{User: "user:alice", Relation: "writer", Object: "project:123"},
+				})
+				return err
+			},
+		},
+		// 4xx errors — span must NOT be marked as errored (expected client conditions).
+		{
+			name:     "ReadObjectTuples/4xx",
+			wantSpan: false,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("Read", mock.Anything, mock.Anything, mock.Anything).
+					Return((*ClientReadResponse)(nil), fakeStatusErr{code: 422})
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.ReadObjectTuples(ctx, "project:123")
+				return err
+			},
+		},
+		{
+			name:     "ReadUserTuples/4xx",
+			wantSpan: false,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("Read", mock.Anything, mock.Anything, mock.Anything).
+					Return((*ClientReadResponse)(nil), fakeStatusErr{code: 422})
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.ReadUserTuples(ctx, "user:alice", "project")
+				return err
+			},
+		},
+		{
+			name:     "ListObjectsByUserAndRelation/4xx",
+			wantSpan: false,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).
+					Return((*ClientListObjectsResponse)(nil), fakeStatusErr{code: 422})
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.ListObjectsByUserAndRelation(ctx, "project", "writer", "user:alice")
+				return err
+			},
+		},
+		{
+			name:     "WriteAndDeleteTuples/4xx",
+			wantSpan: false,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("Write", mock.Anything, mock.Anything).
+					Return((*ClientWriteResponse)(nil), fakeStatusErr{code: 422})
+				return FgaService{client: mc}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				return svc.WriteAndDeleteTuples(ctx,
+					[]ClientTupleKey{{User: "user:alice", Relation: "writer", Object: "project:123"}},
+					nil,
+				)
+			},
+		},
+		{
+			name:     "CheckRelationships/4xx",
+			wantSpan: false,
+			setup: func() FgaService {
+				mc := new(MockFgaClient)
+				mc.On("BatchCheck", mock.Anything, mock.Anything).
+					Return((*openfga.BatchCheckResponse)(nil), fakeStatusErr{code: 422})
+				mockKV := new(MockNatsKeyValue)
+				mockKV.On("Get", mock.Anything, "inv").Return(nil, jetstream.ErrKeyNotFound)
+				return FgaService{client: mc, cacheBucket: mockKV}
+			},
+			run: func(ctx context.Context, svc FgaService) error {
+				_, err := svc.CheckRelationships(ctx, []ClientCheckRequest{
+					{User: "user:alice", Relation: "writer", Object: "project:123"},
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tracer, sr := newOtelTracer(t)
+			ctx, span := tracer.Start(context.Background(), "op")
+
+			svc := tc.setup()
+			err := tc.run(ctx, svc)
+			span.End()
+
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if tc.wantSpan {
+				if !hasException(sr.Ended()) {
+					t.Errorf("RecordError should have been called on the span when %s fails", tc.name)
+				}
+				if !hasErrorStatus(sr.Ended()) {
+					t.Errorf("SetStatus(codes.Error) should have been called on the span when %s fails", tc.name)
+				}
+			} else {
+				if hasException(sr.Ended()) {
+					t.Errorf("RecordError must not be called on the span for a 4xx error in %s", tc.name)
+				}
+				if hasErrorStatus(sr.Ended()) {
+					t.Errorf("SetStatus(codes.Error) must not be called on the span for a 4xx error in %s", tc.name)
+				}
+			}
+		})
+	}
+}

--- a/fga_otel_test.go
+++ b/fga_otel_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -65,14 +64,16 @@ func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
 		setup    func() FgaService
 		run      func(ctx context.Context, svc FgaService) error
 	}{
-		// 5xx / generic errors — span must be marked as errored.
+		// 5xx SDK errors — span must be marked as errored. Uses fakeStatusErr{code:500}
+		// (which implements fgaStatusCoder) to verify that status-coded server errors
+		// are not suppressed by the fgaIs4xx guard (which only skips 400–499).
 		{
 			name:     "ReadObjectTuples/5xx",
 			wantSpan: true,
 			setup: func() FgaService {
 				mc := new(MockFgaClient)
 				mc.On("Read", mock.Anything, mock.Anything, mock.Anything).
-					Return((*ClientReadResponse)(nil), errors.New("fga read error"))
+					Return((*ClientReadResponse)(nil), fakeStatusErr{code: 500})
 				return FgaService{client: mc}
 			},
 			run: func(ctx context.Context, svc FgaService) error {
@@ -86,7 +87,7 @@ func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
 			setup: func() FgaService {
 				mc := new(MockFgaClient)
 				mc.On("Read", mock.Anything, mock.Anything, mock.Anything).
-					Return((*ClientReadResponse)(nil), errors.New("fga read error"))
+					Return((*ClientReadResponse)(nil), fakeStatusErr{code: 500})
 				return FgaService{client: mc}
 			},
 			run: func(ctx context.Context, svc FgaService) error {
@@ -100,7 +101,7 @@ func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
 			setup: func() FgaService {
 				mc := new(MockFgaClient)
 				mc.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).
-					Return((*ClientListObjectsResponse)(nil), errors.New("fga list error"))
+					Return((*ClientListObjectsResponse)(nil), fakeStatusErr{code: 500})
 				return FgaService{client: mc}
 			},
 			run: func(ctx context.Context, svc FgaService) error {
@@ -113,9 +114,10 @@ func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
 			wantSpan: true,
 			setup: func() FgaService {
 				mc := new(MockFgaClient)
-				// Return a non-validation error so the retry path is not taken.
+				// fakeStatusErr{code:500} is not a validation error, so the retry
+				// path is not taken and the error is returned immediately.
 				mc.On("Write", mock.Anything, mock.Anything).
-					Return((*ClientWriteResponse)(nil), errors.New("fga write error"))
+					Return((*ClientWriteResponse)(nil), fakeStatusErr{code: 500})
 				return FgaService{client: mc}
 			},
 			run: func(ctx context.Context, svc FgaService) error {
@@ -131,7 +133,7 @@ func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
 			setup: func() FgaService {
 				mc := new(MockFgaClient)
 				mc.On("BatchCheck", mock.Anything, mock.Anything).
-					Return((*openfga.BatchCheckResponse)(nil), errors.New("fga batch check error"))
+					Return((*openfga.BatchCheckResponse)(nil), fakeStatusErr{code: 500})
 				mockKV := new(MockNatsKeyValue)
 				mockKV.On("Get", mock.Anything, "inv").Return(nil, jetstream.ErrKeyNotFound)
 				return FgaService{client: mc, cacheBucket: mockKV}


### PR DESCRIPTION
## What

Records HTTP client errors on OTel spans at the OpenFGA SDK call sites in `fga.go` — calling `span.RecordError(err)` and `span.SetStatus(codes.Error, err.Error())` when SDK methods return errors. This populates `error.message` and `error.type` on the handler span in Datadog APM and marks the span as errored.

**Changed files:**
- `fga.go` — 6 error-recording sites: `ReadObjectTuples`, `ReadUserTuples`, `ListObjectsByUserAndRelation`, `writeAndDeleteTuplesBatch` (×2), `CheckRelationships`
- `fga_otel_test.go` — OTel tests verifying exception events are recorded on error spans for each method

4xx responses from OpenFGA (e.g. validation errors for malformed tuples) are intentionally excluded — they represent expected application behaviour, not server failures.

## Why

Investigation of Datadog APM showed ~260 error spans per day from `lfx-v2-fga-sync` with empty error details (`error.message`, `error.type` all empty), making triage from the trace view alone impossible.

The `otelhttp` transport marks non-2xx HTTP responses as span errors but never calls `RecordError()`. Recording at the OpenFGA SDK call sites is simpler than a transport wrapper and produces more useful diagnostic context: errors appear on the handler span (the parent) rather than on a child HTTP span.

Issue: LFXV2-2660