### PR TITLE
Add list_objects NATS subject to resolve creatable targets

### DIFF
--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -63,6 +63,69 @@ If no tuples are found:
 
 ---
 
+### List Objects
+
+**Subject:** `lfx.access_check.list_objects`
+
+Resolves, for a batch of `(object_type, relation)` query pairs, which objects a
+user holds each relation on. Uses OpenFGA `ListObjects`, so computed and
+hierarchical relations are included — unlike Read Tuples above, which only
+returns direct tuples. Not limited to any single relation; any relation
+defined in the model can be queried in the same request. Each returned target
+is annotated with `creatable_types`, the artifact types creatable given that
+relation on that object.
+
+**Request** (JSON):
+
+```json
+{
+  "user": "user:auth0|alice",
+  "queries": [
+    {"object_type": "project", "relation": "writer"},
+    {"object_type": "committee", "relation": "writer"}
+  ]
+}
+```
+
+**Response (success)** (JSON):
+
+```json
+{
+  "targets": [
+    {
+      "object": "project:uuid1",
+      "object_type": "project",
+      "relation": "writer",
+      "creatable_types": ["project", "committee", "meeting", "mailing_list", "survey", "vote"]
+    },
+    {
+      "object": "committee:abc",
+      "object_type": "committee",
+      "relation": "writer",
+      "creatable_types": ["meeting", "survey", "vote"]
+    }
+  ]
+}
+```
+
+If no objects are found:
+
+```json
+{"targets": []}
+```
+
+**Response (error)** (JSON):
+
+```json
+{"error": "failed to list objects"}
+```
+
+Targets are cached per `(user, relation, object_type)`, mirroring the access
+check cache. **Order is not guaranteed**; callers must match targets by field,
+not by index.
+
+---
+
 ## Sync API — Generic Handlers
 
 The FGA Sync service provides four universal NATS subjects that work with any

--- a/docs/fga-sync-contract.md
+++ b/docs/fga-sync-contract.md
@@ -21,6 +21,7 @@ this service (`lfx-v2-fga-sync`).
 | `lfx.fga-sync.member_remove` | Remove specific or all relations for a user | `OK` on success if reply subject is provided |
 | `lfx.access_check.request` | Batch authorization check (used by query-service) | text body |
 | `lfx.access_check.read_tuples` | Read all direct tuples for a user + object_type | JSON body |
+| `lfx.access_check.list_objects` | Resolve which objects a user holds a given relation on, per `(object_type, relation)` query batch | JSON body |
 
 Handlers are generic: **publishers do not need fga-sync code changes when adding a
 new resource type that is defined in the OpenFGA model**. Use the generic
@@ -163,6 +164,57 @@ Returns all direct OpenFGA tuples for a given user and object type. Paginates in
 // Response error
 {"error": "failed to read tuples"}
 ```
+
+### `lfx.access_check.list_objects`
+
+Resolves, for a batch of `(object_type, relation)` query pairs, which objects a
+user holds each relation on — evaluated via OpenFGA `ListObjects`, so computed
+and hierarchical relations are included (unlike `read_tuples`, which only
+returns direct tuples). Not limited to any single relation or use case; any
+relation defined in the model can be queried. Each returned target is
+annotated with `creatable_types`, the artifact types creatable given that
+relation on that object — this mapping is domain knowledge intentionally held
+in fga-sync (see Model Boundaries below) and reviewed jointly with the
+consuming client's owner.
+
+```json
+// Request
+{
+  "user": "user:auth0|alice",
+  "queries": [
+    {"object_type": "project", "relation": "writer"},
+    {"object_type": "committee", "relation": "writer"}
+  ]
+}
+
+// Response success
+{
+  "targets": [
+    {
+      "object": "project:uuid1",
+      "object_type": "project",
+      "relation": "writer",
+      "creatable_types": ["project", "committee", "meeting", "mailing_list", "survey", "vote"]
+    },
+    {
+      "object": "committee:abc",
+      "object_type": "committee",
+      "relation": "writer",
+      "creatable_types": ["meeting", "survey", "vote"]
+    }
+  ]
+}
+
+// Response empty
+{"targets": []}
+
+// Response error
+{"error": "failed to list objects"}
+```
+
+Targets are cached per `(user, relation, object_type)`, mirroring the
+`access_check` cache pattern below. **Order is not guaranteed**; callers must
+match targets by field, not by index.
 
 ## OpenFGA Model Boundaries
 

--- a/fga.go
+++ b/fga.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base32"
+	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
@@ -188,6 +189,55 @@ func (s FgaService) ListObjectsByUserAndRelation(
 	}
 
 	return resp.Objects, nil
+}
+
+// ListObjectsCached is a cache-aware wrapper around ListObjectsByUserAndRelation,
+// following the same cache/invalidation pattern as CheckRelationships: results
+// are cached per (user, relation, objectType) tuple and treated as stale once
+// older than the last cache invalidation.
+func (s FgaService) ListObjectsCached(ctx context.Context, objectType, relation, user string) ([]string, error) {
+	if !useCache {
+		return s.ListObjectsByUserAndRelation(ctx, objectType, relation, user)
+	}
+
+	lastInvalidation, err := s.getLastCacheInvalidation(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey := "list." + cacheKeyEncoder.EncodeToString([]byte(user+"#"+relation+"@"+objectType))
+	entry, errCache := s.cacheBucket.Get(ctx, cacheKey)
+	switch {
+	case errCache == jetstream.ErrKeyNotFound:
+		cacheMisses.Add(1)
+	case errCache != nil:
+		// Not expected, but log and fall through to a fresh OpenFGA query rather
+		// than failing the request.
+		logger.With(errKey, errCache).ErrorContext(ctx, "cache error; bypassing cache")
+	case lastInvalidation.After(entry.Created()):
+		cacheStaleHits.Add(1)
+	default:
+		var objects []string
+		errUnmarshal := json.Unmarshal(entry.Value(), &objects)
+		if errUnmarshal == nil {
+			cacheHits.Add(1)
+			return objects, nil
+		}
+		logger.With(errKey, errUnmarshal).ErrorContext(ctx, "failed to unmarshal cached list objects entry")
+	}
+
+	objects, err := s.ListObjectsByUserAndRelation(ctx, objectType, relation, user)
+	if err != nil {
+		return nil, err
+	}
+
+	if data, errMarshal := json.Marshal(objects); errMarshal == nil {
+		if _, errPut := s.cacheBucket.Put(ctx, cacheKey, data); errPut != nil {
+			logger.With(errKey, errPut).ErrorContext(ctx, "failed to cache list objects result")
+		}
+	}
+
+	return objects, nil
 }
 
 func (s FgaService) getRelationsMap(object string, relations []ClientTupleKey) (map[string]ClientTupleKey, error) {

--- a/handler_list_objects.go
+++ b/handler_list_objects.go
@@ -1,0 +1,127 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package main provides the fga-sync service entry point and supporting types.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
+)
+
+// listObjectsTimeout is the maximum time allowed for the batch of OpenFGA
+// ListObjects calls.
+const listObjectsTimeout = 10 * time.Second
+
+// listObjectsHandler handles requests to resolve, for a batch of
+// (object_type, relation) queries, which objects a user holds each relation
+// on. It responds with a JSON-encoded ListObjectsResponse where each target
+// is annotated with the artifact types creatable on it.
+func (h *HandlerService) listObjectsHandler(ctx context.Context, message INatsMsg) error {
+	ctx, cancel := context.WithTimeout(ctx, listObjectsTimeout)
+	defer cancel()
+
+	// Unmarshal the JSON request payload.
+	var req types.ListObjectsRequest
+	if err := json.Unmarshal(message.Data(), &req); err != nil {
+		logger.With(errKey, err).WarnContext(ctx, "failed to unmarshal list objects request")
+		return h.respondListObjectsError(ctx, message, "invalid request payload")
+	}
+
+	if req.User == "" || len(req.Queries) == 0 {
+		logger.With(
+			"user", req.User,
+			"query_count", len(req.Queries),
+		).WarnContext(ctx, "list objects request missing required fields")
+		return h.respondListObjectsError(ctx, message, "user and queries are required")
+	}
+
+	for _, q := range req.Queries {
+		if q.ObjectType == "" || q.Relation == "" {
+			logger.With(
+				"object_type", q.ObjectType,
+				"relation", q.Relation,
+			).WarnContext(ctx, "list objects request has an incomplete query")
+			return h.respondListObjectsError(ctx, message, "object_type and relation are required for each query")
+		}
+		if strings.Contains(q.ObjectType, ":") {
+			logger.With("object_type", q.ObjectType).WarnContext(ctx, "list objects request contains invalid object_type")
+			return h.respondListObjectsError(ctx, message, "object_type must not contain ':'")
+		}
+	}
+
+	logger.With(
+		"user", req.User,
+		"query_count", len(req.Queries),
+	).InfoContext(ctx, "handling list objects request")
+
+	// Resolve each (object_type, relation) query and annotate results with
+	// their creatable artifact types.
+	targets := make([]types.ListObjectsTarget, 0)
+	for _, q := range req.Queries {
+		objects, err := h.fgaService.ListObjectsCached(ctx, q.ObjectType, q.Relation, req.User)
+		if err != nil {
+			logger.With(
+				errKey, err,
+				"user", req.User,
+				"object_type", q.ObjectType,
+				"relation", q.Relation,
+			).ErrorContext(ctx, "failed to list objects")
+			return h.respondListObjectsError(ctx, message, "failed to list objects")
+		}
+
+		creatableTypes := types.CreatableTypesFor(q.ObjectType, q.Relation)
+		for _, object := range objects {
+			targets = append(targets, types.ListObjectsTarget{
+				Object:         object,
+				ObjectType:     q.ObjectType,
+				Relation:       q.Relation,
+				CreatableTypes: creatableTypes,
+			})
+		}
+	}
+
+	resp := types.ListObjectsResponse{Targets: targets}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		logger.With(errKey, err).ErrorContext(ctx, "failed to marshal list objects response")
+		return h.respondListObjectsError(ctx, message, "failed to marshal response")
+	}
+
+	if message.Reply() != "" {
+		if errRespond := message.Respond(data); errRespond != nil {
+			logger.With(errKey, errRespond).WarnContext(ctx, "failed to send list objects reply")
+			return errRespond
+		}
+		logger.With(
+			"user", req.User,
+			"query_count", len(req.Queries),
+			"target_count", len(targets),
+		).InfoContext(ctx, "sent list objects response")
+	}
+
+	return nil
+}
+
+// respondListObjectsError sends a JSON error response over NATS and returns a
+// formatted error so the subscription loop can log it consistently with other
+// handlers. This helper does not log — callers are responsible for logging
+// before calling it.
+func (h *HandlerService) respondListObjectsError(_ context.Context, message INatsMsg, errMsg string) error {
+	if message.Reply() != "" {
+		resp := types.ListObjectsResponse{Error: errMsg}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			return fmt.Errorf("list objects: %s (marshal error response: %w)", errMsg, err)
+		}
+		if errRespond := message.Respond(data); errRespond != nil {
+			return fmt.Errorf("list objects: %s (send error reply: %w)", errMsg, errRespond)
+		}
+	}
+	return fmt.Errorf("list objects: %s", errMsg)
+}

--- a/handler_list_objects_test.go
+++ b/handler_list_objects_test.go
@@ -1,0 +1,370 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package main provides the fga-sync service entry point and supporting types.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/openfga/go-sdk/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
+)
+
+// TestListObjectsCached tests the ListObjectsCached method of FgaService.
+func TestListObjectsCached(t *testing.T) {
+	tests := []struct {
+		name            string
+		objectType      string
+		relation        string
+		user            string
+		useCacheValue   bool
+		mockClientSetup func(*MockFgaClient)
+		mockCacheSetup  func(*MockKeyValue)
+		expectedResult  []string
+		expectError     bool
+		description     string
+	}{
+		{
+			name:          "cache disabled queries OpenFGA directly",
+			objectType:    "project",
+			relation:      "writer",
+			user:          "user:auth0|alice",
+			useCacheValue: false,
+			mockClientSetup: func(m *MockFgaClient) {
+				m.On("ListObjects", mock.Anything, mock.MatchedBy(func(req client.ClientListObjectsRequest) bool {
+					return req.User == "user:auth0|alice" && req.Relation == "writer" && req.Type == "project"
+				}), mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{"project:uuid1"},
+				}, nil).Once()
+			},
+			mockCacheSetup: func(_ *MockKeyValue) {},
+			expectedResult: []string{"project:uuid1"},
+			expectError:    false,
+			description:    "should bypass cache entirely when useCache is false",
+		},
+		{
+			name:          "cache enabled, cache miss queries OpenFGA and caches result",
+			objectType:    "committee",
+			relation:      "writer",
+			user:          "user:auth0|bob",
+			useCacheValue: true,
+			mockClientSetup: func(m *MockFgaClient) {
+				m.On("ListObjects", mock.Anything, mock.MatchedBy(func(req client.ClientListObjectsRequest) bool {
+					return req.User == "user:auth0|bob" && req.Relation == "writer" && req.Type == "committee"
+				}), mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{"committee:abc"},
+				}, nil).Once()
+			},
+			mockCacheSetup: func(m *MockKeyValue) {
+				m.On("Get", mock.Anything, "inv").Return(nil, jetstream.ErrKeyNotFound)
+				m.SetNotFound("list.OVZWK4R2MF2XI2BQPRRG6YRDO5ZGS5DFOJAGG33NNVUXI5DFMU")
+			},
+			expectedResult: []string{"committee:abc"},
+			expectError:    false,
+			description:    "should query OpenFGA and cache the fresh result on a cache miss",
+		},
+		{
+			name:          "cache enabled, fresh cache hit skips OpenFGA",
+			objectType:    "project",
+			relation:      "writer",
+			user:          "user:auth0|carol",
+			useCacheValue: true,
+			mockClientSetup: func(_ *MockFgaClient) {
+				// No ListObjects call expected; a fresh cache hit must short-circuit.
+			},
+			mockCacheSetup: func(m *MockKeyValue) {
+				m.On("Get", mock.Anything, "inv").Return(nil, jetstream.ErrKeyNotFound)
+			},
+			expectedResult: []string{"project:cached-uuid"},
+			expectError:    false,
+			description:    "should return the cached value without calling OpenFGA",
+		},
+		{
+			name:          "cache enabled, stale cache entry re-queries OpenFGA",
+			objectType:    "project",
+			relation:      "writer",
+			user:          "user:auth0|dave",
+			useCacheValue: true,
+			mockClientSetup: func(m *MockFgaClient) {
+				m.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{"project:fresh-uuid"},
+				}, nil).Once()
+			},
+			mockCacheSetup: func(_ *MockKeyValue) {},
+			expectedResult: []string{"project:fresh-uuid"},
+			expectError:    false,
+			description:    "should ignore a cache entry older than the last invalidation",
+		},
+		{
+			name:          "OpenFGA error propagates",
+			objectType:    "project",
+			relation:      "writer",
+			user:          "user:auth0|err",
+			useCacheValue: false,
+			mockClientSetup: func(m *MockFgaClient) {
+				m.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).Return(
+					(*client.ClientListObjectsResponse)(nil), errors.New("openfga unavailable"),
+				).Once()
+			},
+			mockCacheSetup: func(_ *MockKeyValue) {},
+			expectedResult: nil,
+			expectError:    true,
+			description:    "should propagate OpenFGA errors",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useCache = tt.useCacheValue
+			t.Cleanup(func() { useCache = false })
+
+			mockClient := &MockFgaClient{}
+			tt.mockClientSetup(mockClient)
+			mockCache := NewMockKeyValue()
+			tt.mockCacheSetup(mockCache)
+
+			svc := FgaService{client: mockClient, cacheBucket: mockCache}
+
+			// Pre-seed a fresh cache entry for the "fresh cache hit" case, and a
+			// stale one (before the invalidation marker) for the "stale" case.
+			switch tt.name {
+			case "cache enabled, fresh cache hit skips OpenFGA":
+				data, err := json.Marshal(tt.expectedResult)
+				assert.NoError(t, err)
+				_, err = mockCache.Put(t.Context(), "list.OVZWK4R2MF2XI2BQPRRWC4TPNQRXO4TJORSXEQDQOJXWUZLDOQ", data)
+				assert.NoError(t, err)
+			case "cache enabled, stale cache entry re-queries OpenFGA":
+				data, err := json.Marshal([]string{"project:stale-uuid"})
+				assert.NoError(t, err)
+				_, err = mockCache.Put(t.Context(), "list.OVZWK4R2MF2XI2BQPRSGC5TFEN3XE2LUMVZEA4DSN5VGKY3U", data)
+				assert.NoError(t, err)
+				_, err = mockCache.Put(t.Context(), "inv", []byte("1"))
+				assert.NoError(t, err)
+			}
+
+			objects, err := svc.ListObjectsCached(t.Context(), tt.objectType, tt.relation, tt.user)
+
+			if tt.expectError {
+				assert.Error(t, err, tt.description)
+			} else {
+				assert.NoError(t, err, tt.description)
+				assert.Equal(t, tt.expectedResult, objects, tt.description)
+			}
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+// TestListObjectsHandler tests the listObjectsHandler function.
+func TestListObjectsHandler(t *testing.T) {
+	tests := []struct {
+		name         string
+		messageData  []byte
+		replySubject string
+		mockSetup    func(*MockFgaClient, *MockNatsMsg)
+		expectError  bool
+	}{
+		{
+			name:         "success returns annotated targets",
+			messageData:  []byte(`{"user":"user:auth0|alice","queries":[{"object_type":"project","relation":"writer"}]}`),
+			replySubject: "reply.123",
+			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
+				m.On("ListObjects", mock.Anything, mock.MatchedBy(func(req client.ClientListObjectsRequest) bool {
+					return req.User == "user:auth0|alice" && req.Relation == "writer" && req.Type == "project"
+				}), mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{"project:uuid1"},
+				}, nil).Once()
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return len(resp.Targets) == 1 &&
+						resp.Targets[0].Object == "project:uuid1" &&
+						resp.Targets[0].ObjectType == "project" &&
+						resp.Targets[0].Relation == "writer" &&
+						len(resp.Targets[0].CreatableTypes) > 0 &&
+						resp.Error == ""
+				})).Return(nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:         "multiple queries aggregate into one target list",
+			messageData:  []byte(`{"user":"user:auth0|alice","queries":[{"object_type":"project","relation":"writer"},{"object_type":"committee","relation":"writer"}]}`),
+			replySubject: "reply.456",
+			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
+				m.On("ListObjects", mock.Anything, mock.MatchedBy(func(req client.ClientListObjectsRequest) bool {
+					return req.Type == "project"
+				}), mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{"project:uuid1"},
+				}, nil).Once()
+				m.On("ListObjects", mock.Anything, mock.MatchedBy(func(req client.ClientListObjectsRequest) bool {
+					return req.Type == "committee"
+				}), mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{"committee:abc"},
+				}, nil).Once()
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return len(resp.Targets) == 2 && resp.Error == ""
+				})).Return(nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:         "empty results returned as empty array",
+			messageData:  []byte(`{"user":"user:auth0|nobody","queries":[{"object_type":"project","relation":"writer"}]}`),
+			replySubject: "reply.789",
+			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
+				m.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{},
+				}, nil).Once()
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Targets != nil && len(resp.Targets) == 0 && resp.Error == ""
+				})).Return(nil).Once()
+			},
+			expectError: false,
+		},
+		{
+			name:         "OpenFGA error returns generic JSON error",
+			messageData:  []byte(`{"user":"user:auth0|err","queries":[{"object_type":"project","relation":"writer"}]}`),
+			replySubject: "reply.err",
+			mockSetup: func(m *MockFgaClient, msg *MockNatsMsg) {
+				m.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).Return(
+					(*client.ClientListObjectsResponse)(nil), errors.New("store unavailable"),
+				).Once()
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error == "failed to list objects"
+				})).Return(nil).Once()
+			},
+			expectError: true,
+		},
+		{
+			name:         "invalid JSON payload returns error response",
+			messageData:  []byte(`not-json`),
+			replySubject: "reply.bad",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error == "invalid request payload"
+				})).Return(nil).Once()
+			},
+			expectError: true,
+		},
+		{
+			name:         "missing user field returns error response",
+			messageData:  []byte(`{"queries":[{"object_type":"project","relation":"writer"}]}`),
+			replySubject: "reply.no-user",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error != ""
+				})).Return(nil).Once()
+			},
+			expectError: true,
+		},
+		{
+			name:         "empty queries returns error response",
+			messageData:  []byte(`{"user":"user:auth0|alice","queries":[]}`),
+			replySubject: "reply.no-queries",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error == "user and queries are required"
+				})).Return(nil).Once()
+			},
+			expectError: true,
+		},
+		{
+			name:         "query missing relation returns error response",
+			messageData:  []byte(`{"user":"user:auth0|alice","queries":[{"object_type":"project"}]}`),
+			replySubject: "reply.no-relation",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error == "object_type and relation are required for each query"
+				})).Return(nil).Once()
+			},
+			expectError: true,
+		},
+		{
+			name:         "object_type with colon is rejected",
+			messageData:  []byte(`{"user":"user:auth0|alice","queries":[{"object_type":"project:","relation":"writer"}]}`),
+			replySubject: "reply.colon",
+			mockSetup: func(_ *MockFgaClient, msg *MockNatsMsg) {
+				msg.On("Respond", mock.MatchedBy(func(data []byte) bool {
+					var resp types.ListObjectsResponse
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return false
+					}
+					return resp.Error == "object_type must not contain ':'"
+				})).Return(nil).Once()
+			},
+			expectError: true,
+		},
+		{
+			name:         "no reply subject — no Respond call",
+			messageData:  []byte(`{"user":"user:auth0|alice","queries":[{"object_type":"project","relation":"writer"}]}`),
+			replySubject: "",
+			mockSetup: func(m *MockFgaClient, _ *MockNatsMsg) {
+				m.On("ListObjects", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientListObjectsResponse{
+					Objects: []string{},
+				}, nil).Once()
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := setupService()
+			msg := CreateMockNatsMsg(tt.messageData)
+			msg.reply = tt.replySubject
+
+			tt.mockSetup(service.fgaService.client.(*MockFgaClient), msg)
+
+			assert.NotPanics(t, func() {
+				err := service.listObjectsHandler(context.Background(), msg)
+				if tt.expectError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+
+			msg.AssertExpectations(t)
+			service.fgaService.client.(*MockFgaClient).AssertExpectations(t)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -383,6 +383,11 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 			handler:     handlerService.readTuplesHandler,
 			description: "read tuples",
 		},
+		{
+			subject:     constants.ListObjectsSubject,
+			handler:     handlerService.listObjectsHandler,
+			description: "list objects",
+		},
 		// Generic handlers (resource-agnostic)
 		{
 			subject:     constants.GenericUpdateAccessSubject,

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -19,6 +19,12 @@ const (
 	// ReadTuplesSubject is the subject for reading a user's direct tuples by object type.
 	// The subject is of the form: lfx.access_check.read_tuples
 	ReadTuplesSubject = "lfx.access_check.read_tuples"
+
+	// ListObjectsSubject is the subject for resolving which objects a user holds
+	// a given relation on, per (object_type, relation) query. Not limited to
+	// creation checks — any relation defined in the model can be queried.
+	// The subject is of the form: lfx.access_check.list_objects
+	ListObjectsSubject = "lfx.access_check.list_objects"
 )
 
 // NATS queue subjects that the FGA sync service handles messages about.

--- a/pkg/types/creatable_types.go
+++ b/pkg/types/creatable_types.go
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package types contains shared message types for the fga-sync service.
+package types
+
+// creatableTypesByRelation maps object_type -> relation -> the artifact types
+// creatable on a target holding that relation. This mirrors the client's
+// writerGuard rules; it must never grant a type/target combination writerGuard
+// would deny. The exact table is pending review with the writerGuard/client
+// owner (see LFXV2-2753).
+var creatableTypesByRelation = map[string]map[string][]string{
+	"project": {
+		"writer":              {"project", "committee", "meeting", "mailing_list", "survey", "vote"},
+		"meeting_coordinator": {"meeting"},
+	},
+	"committee": {
+		"writer": {"meeting", "survey", "vote"},
+	},
+}
+
+// CreatableTypesFor returns the artifact types creatable on a target of the
+// given object type where the user holds the given relation. Returns an empty
+// (non-nil) slice when no mapping is defined for the pair.
+func CreatableTypesFor(objectType, relation string) []string {
+	if byRelation, ok := creatableTypesByRelation[objectType]; ok {
+		if creatableTypes, ok := byRelation[relation]; ok {
+			return creatableTypes
+		}
+	}
+	return []string{}
+}

--- a/pkg/types/list_objects.go
+++ b/pkg/types/list_objects.go
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package types contains shared message types for the fga-sync service.
+package types
+
+// ListObjectsRequest is the JSON payload received over NATS for the
+// lfx.access_check.list_objects subject.
+type ListObjectsRequest struct {
+	User    string             `json:"user"`
+	Queries []ListObjectsQuery `json:"queries"`
+}
+
+// ListObjectsQuery is a single (object_type, relation) pair to resolve via
+// OpenFGA ListObjects.
+type ListObjectsQuery struct {
+	ObjectType string `json:"object_type"`
+	Relation   string `json:"relation"`
+}
+
+// ListObjectsTarget is a single object the user holds the given relation on,
+// annotated with the artifact types creatable on it.
+type ListObjectsTarget struct {
+	Object         string   `json:"object"`
+	ObjectType     string   `json:"object_type"`
+	Relation       string   `json:"relation"`
+	CreatableTypes []string `json:"creatable_types"`
+}
+
+// ListObjectsResponse is the JSON response sent back over NATS for the
+// lfx.access_check.list_objects subject. Error is set on failure.
+type ListObjectsResponse struct {
+	Targets []ListObjectsTarget `json:"targets"`
+	Error   string              `json:"error,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Adds `lfx.access_check.list_objects`, a batch NATS request/reply that resolves which objects a user holds a given relation on via OpenFGA `ListObjects` (covers computed/hierarchical relations, unlike `read_tuples`)
- Each returned target is annotated with the artifact types creatable on it, via a `(object_type, relation) -> creatable_types` table in `pkg/types/creatable_types.go` (illustrative, pending review with the writerGuard/client owner)
- Adds a cache-aware wrapper (`ListObjectsCached`) mirroring the existing access-check cache pattern
- Updates `docs/fga-sync-contract.md` and `docs/client-guide.md` with the new subject

Issue: LFXV2-2753