### PR TITLE
feat: route membership sync through shared JetStream access-mutation consumer

### DIFF
--- a/.claude/skills/fga-sync-dev/references/nats-messaging.md
+++ b/.claude/skills/fga-sync-dev/references/nats-messaging.md
@@ -8,9 +8,10 @@ Read `lfx-skills:lfx-platform-architecture` for cross-repo NATS and KV ownership
 ## Subscriptions
 
 Core subscriptions are wired in `createQueueSubscriptions` in `main.go` and
-share `constants.FgaSyncQueue`. Access mutations use one durable JetStream
-consumer with `MaxAckPending: 1`, so only one update or delete is pending
-globally.
+share `constants.FgaSyncQueue`. All four generic sync subjects
+(`update_access`, `delete_access`, `member_put`, `member_remove`) share one
+durable JetStream consumer with `MaxAckPending: 1`, so only one message is
+pending globally.
 
 | Subject (constant) | Value | Handler | Purpose |
 | --- | --- | --- | --- |
@@ -18,8 +19,8 @@ globally.
 | `ReadTuplesSubject` | `lfx.access_check.read_tuples` | `readTuplesHandler` | Read direct tuples for a user + object type |
 | `GenericUpdateAccessSubject` | `lfx.fga-sync.update_access` | `genericUpdateAccessHandler` | JetStream full sync of publisher-managed relations |
 | `GenericDeleteAccessSubject` | `lfx.fga-sync.delete_access` | `genericDeleteAccessHandler` | JetStream removal of publisher-managed relations; preserves `team:*` grants |
-| `GenericMemberPutSubject` | `lfx.fga-sync.member_put` | `genericMemberPutHandler` | Add or update a per-user relation |
-| `GenericMemberRemoveSubject` | `lfx.fga-sync.member_remove` | `genericMemberRemoveHandler` | Remove a per-user relation |
+| `GenericMemberPutSubject` | `lfx.fga-sync.member_put` | `genericMemberPutHandler` | JetStream add or update of a per-user relation |
+| `GenericMemberRemoveSubject` | `lfx.fga-sync.member_remove` | `genericMemberRemoveHandler` | JetStream removal of a per-user relation |
 
 Subject strings live in `pkg/constants/nats.go`. Do not hardcode them at call sites.
 
@@ -27,11 +28,11 @@ Subject strings live in `pkg/constants/nats.go`. Do not hardcode them at call si
 
 - `lfx.access_check.request`: plain text, one line per requested check, tab-delimited `{object}#{relation}@user:{principal}\t{true|false}`. Missing lines mean denied. Replies are not ordered; callers must match by request token.
 - `lfx.access_check.read_tuples`: JSON. Success is `{"results": ["object#relation@user:{principal}", ...]}`. Failure is `{"error": "..."}`.
-- `update_access` and `delete_access`: no application reply. The consumer ACKs
-  success, leaves transient failures unacknowledged, and terminates proven local
-  validation failures.
-- `member_put` and `member_remove`: `OK` on success only when
-  `message.Reply() != ""`; failures have no standardized NATS error body.
+- None of the four generic sync subjects (`update_access`, `delete_access`,
+  `member_put`, `member_remove`) send an application reply. The shared
+  consumer ACKs success, leaves transient failures unacknowledged, and
+  terminates proven local validation failures; JetStream ACK/terminate/
+  redeliver is the only delivery signal.
 
 ## When adding a new subscription
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Dependencies you need but should get from [lfx-v2-helm](https://github.com/linux
    ```bash
    # Using NATS CLI (if available)
    nats kv add fga-sync-cache --history=20 --storage=file --max-value-size=10485760 --max-bucket-size=1073741824
-   nats stream add fga-sync-events --subjects=lfx.fga-sync.update_access --subjects=lfx.fga-sync.delete_access --storage=file --retention=limits --max-age=24h
+   nats stream add fga-sync-events --subjects=lfx.fga-sync.update_access --subjects=lfx.fga-sync.delete_access --subjects=lfx.fga-sync.member_put --subjects=lfx.fga-sync.member_remove --storage=file --retention=limits --max-age=24h
 
    # Or using kubectl if running in Kubernetes
    kubectl exec -n lfx deploy/nats-box -- nats kv add fga-sync-cache --history=20 --storage=file --max-value-size=10485760 --max-bucket-size=1073741824 --ttl=3h
-   kubectl exec -n lfx deploy/nats-box -- nats stream add fga-sync-events --subjects=lfx.fga-sync.update_access --subjects=lfx.fga-sync.delete_access --storage=file --retention=limits --max-age=24h
+   kubectl exec -n lfx deploy/nats-box -- nats stream add fga-sync-events --subjects=lfx.fga-sync.update_access --subjects=lfx.fga-sync.delete_access --subjects=lfx.fga-sync.member_put --subjects=lfx.fga-sync.member_remove --storage=file --retention=limits --max-age=24h
    ```
 
 6. **Run the service**:

--- a/access_mutation.go
+++ b/access_mutation.go
@@ -138,10 +138,18 @@ type accessMutationConsumerManager struct {
 }
 
 // accessMutationConsumerConfig returns the durable pull consumer configuration
-// shared by update_access and delete_access. MaxAckPending of 1 serializes
-// delivery so full-state updates for an object are never applied out of order;
-// BackOff spaces redelivery attempts over roughly 94 minutes before the
-// max-delivery advisory fires.
+// shared by update_access, delete_access, member_put, and member_remove.
+// MaxAckPending of 1 serializes delivery so full-state updates for an object
+// are never applied out of order, and so a member_put cannot be applied ahead
+// of a delete_access for the same object; BackOff spaces redelivery attempts
+// over roughly 94 minutes before the max-delivery advisory fires.
+//
+// FilterSubjects is set explicitly rather than left empty so the consumer's
+// scope is a declared property of the deployed binary instead of an implicit
+// consequence of whatever subjects the stream happens to carry. An empty
+// filter would let a Helm-only stream change (widening to the membership
+// subjects) silently change what this consumer receives, ahead of a service
+// version that knows how to route them.
 //
 // DeliverNewPolicy is equivalent to DeliverAllPolicy for the empty stream used
 // at the initial cutover. On normal restarts the existing durable resumes from
@@ -175,6 +183,12 @@ func accessMutationConsumerConfig() jetstream.ConsumerConfig {
 			30 * time.Minute,
 		},
 		MaxAckPending: 1,
+		FilterSubjects: []string{
+			constants.GenericUpdateAccessSubject,
+			constants.GenericDeleteAccessSubject,
+			constants.GenericMemberPutSubject,
+			constants.GenericMemberRemoveSubject,
+		},
 	}
 }
 
@@ -388,6 +402,10 @@ func dispatchAccessMutation(
 		return handlerService.genericUpdateAccessHandler(ctx, message)
 	case constants.GenericDeleteAccessSubject:
 		return handlerService.genericDeleteAccessHandler(ctx, message)
+	case constants.GenericMemberPutSubject:
+		return handlerService.genericMemberPutHandler(ctx, message)
+	case constants.GenericMemberRemoveSubject:
+		return handlerService.genericMemberRemoveHandler(ctx, message)
 	default:
 		return newTerminalValidationError(errors.New("unsupported access mutation subject"))
 	}

--- a/access_mutation_test.go
+++ b/access_mutation_test.go
@@ -113,7 +113,12 @@ func TestAccessMutationConsumerConfig(t *testing.T) {
 		15 * time.Minute,
 		30 * time.Minute,
 	}, config.BackOff)
-	assert.Empty(t, config.FilterSubjects)
+	assert.Equal(t, []string{
+		constants.GenericUpdateAccessSubject,
+		constants.GenericDeleteAccessSubject,
+		constants.GenericMemberPutSubject,
+		constants.GenericMemberRemoveSubject,
+	}, config.FilterSubjects)
 }
 
 func TestAccessMutationAttemptContextUsesNinetySecondDeadline(t *testing.T) {
@@ -176,6 +181,35 @@ func TestProcessAccessMutationMessageOutcomes(t *testing.T) {
 			fgaErr:         assert.AnError,
 			transientDelta: 1,
 		},
+		{
+			name: "member_put dispatches to its handler and ACKs",
+			payload: `{"object_type":"committee","operation":"member_put",` +
+				`"data":{"uid":"resource-1","username":"user-1","relations":["member"]}}`,
+			subject:      constants.GenericMemberPutSubject,
+			wantAckCalls: 1,
+			ackDelta:     1,
+		},
+		{
+			name:         "member_remove dispatches to its handler and ACKs",
+			payload:      `{"object_type":"committee","operation":"member_remove","data":{"uid":"resource-1","username":"user-1"}}`,
+			subject:      constants.GenericMemberRemoveSubject,
+			wantAckCalls: 1,
+			ackDelta:     1,
+		},
+		{
+			name:          "member_put malformed payload terminates",
+			payload:       `{`,
+			subject:       constants.GenericMemberPutSubject,
+			wantTermCalls: 1,
+			terminalDelta: 1,
+		},
+		{
+			name:          "member_remove malformed payload terminates",
+			payload:       `{`,
+			subject:       constants.GenericMemberRemoveSubject,
+			wantTermCalls: 1,
+			terminalDelta: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -185,6 +219,9 @@ func TestProcessAccessMutationMessageOutcomes(t *testing.T) {
 			fgaClient.
 				On("Read", mock.Anything, mock.Anything, client.ClientReadOptions{}).
 				Return(&client.ClientReadResponse{}, tt.fgaErr)
+			fgaClient.
+				On("Write", mock.Anything, mock.Anything, mock.Anything).
+				Return(&client.ClientWriteResponse{}, nil)
 
 			message := &testAccessMutationMessage{
 				data:    []byte(tt.payload),
@@ -292,7 +329,7 @@ func TestProcessAccessMutationMessageAcksCacheInvalidationWarning(t *testing.T) 
 		On("Read", mock.Anything, mock.Anything, client.ClientReadOptions{}).
 		Return(&client.ClientReadResponse{}, nil)
 	fgaClient.
-		On("Write", mock.Anything, mock.Anything).
+		On("Write", mock.Anything, mock.Anything, mock.Anything).
 		Return(&client.ClientWriteResponse{}, nil)
 	service.fgaService.cacheBucket.(*MockKeyValue).SetError(assert.AnError)
 	message := &testAccessMutationMessage{
@@ -388,11 +425,11 @@ func TestCoreSubscriptionsExcludeMigratedAccessSubjects(t *testing.T) {
 
 	assert.False(t, subjects[constants.GenericUpdateAccessSubject])
 	assert.False(t, subjects[constants.GenericDeleteAccessSubject])
+	assert.False(t, subjects[constants.GenericMemberPutSubject])
+	assert.False(t, subjects[constants.GenericMemberRemoveSubject])
 	assert.True(t, subjects[constants.AccessCheckSubject])
 	assert.True(t, subjects[constants.ReadTuplesSubject])
-	assert.True(t, subjects[constants.GenericMemberPutSubject])
-	assert.True(t, subjects[constants.GenericMemberRemoveSubject])
-	assert.Len(t, subjects, 4)
+	assert.Len(t, subjects, 2)
 }
 
 func TestHandleMaxDeliveryAdvisoryEnrichesObjectContext(t *testing.T) {

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -89,7 +89,7 @@ nats:
     # Splitting them across transports would let a delayed update recreate
     # tuples a later deletion already removed. Do not apply the membership
     # subjects below until the release-2 gate in
-    # openspec/changes/fga-sync-jetstream-membership/tasks.md (group 6) is
+    # docs/runbooks/fga-sync-jetstream-cutover.md (Phase 2 preconditions) is
     # cleared: all four publisher services must be asynchronous-only for
     # member_put/member_remove first, because stream capture — not core
     # subscription removal — is the point of no return for a request/reply

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -74,7 +74,8 @@ nats:
     # compression is a boolean to determine if the KV bucket should be compressed
     compression: true
 
-  # accessMutationStream persists ordered update_access and delete_access messages.
+  # accessMutationStream persists ordered update_access, delete_access,
+  # member_put, and member_remove messages.
   accessMutationStream:
     # creation controls whether the stream CRD is provisioned by this chart
     creation: true
@@ -82,13 +83,22 @@ nats:
     keep: true
     # name is the NATS stream name
     name: fga-sync-events
-    # subjects captures both access mutation subjects on one stream so a single
-    # ordered consumer applies updates and deletions for an object in publish
-    # order. Splitting them across transports would let a delayed update recreate
-    # tuples a later deletion already removed.
+    # subjects captures all four access-mutation and membership subjects on one
+    # stream so a single ordered consumer applies updates, deletions, and
+    # membership changes for an object in publish order across both families.
+    # Splitting them across transports would let a delayed update recreate
+    # tuples a later deletion already removed. Do not apply the membership
+    # subjects below until the release-2 gate in
+    # openspec/changes/fga-sync-jetstream-membership/tasks.md (group 6) is
+    # cleared: all four publisher services must be asynchronous-only for
+    # member_put/member_remove first, because stream capture — not core
+    # subscription removal — is the point of no return for a request/reply
+    # caller.
     subjects:
       - lfx.fga-sync.update_access
       - lfx.fga-sync.delete_access
+      - lfx.fga-sync.member_put
+      - lfx.fga-sync.member_remove
     # retention keeps messages up to maxAge; they are not accumulated indefinitely
     retention: limits
     # maxAge must cover queue wait plus retry, not just the ~94 minute retry

--- a/charts/lfx-v2-fga-sync/values.yaml
+++ b/charts/lfx-v2-fga-sync/values.yaml
@@ -87,13 +87,15 @@ nats:
     # stream so a single ordered consumer applies updates, deletions, and
     # membership changes for an object in publish order across both families.
     # Splitting them across transports would let a delayed update recreate
-    # tuples a later deletion already removed. Do not apply the membership
-    # subjects below until the release-2 gate in
-    # docs/runbooks/fga-sync-jetstream-cutover.md (Phase 2 preconditions) is
+    # tuples a later deletion already removed. Do not deploy the two
+    # membership subjects below to an environment until the preconditions in
+    # docs/runbooks/fga-sync-jetstream-cutover.md (Phase 2 preconditions) are
     # cleared: all four publisher services must be asynchronous-only for
     # member_put/member_remove first, because stream capture — not core
     # subscription removal — is the point of no return for a request/reply
-    # caller.
+    # caller. This chart version and the fga-sync binary that removes the
+    # core member_put/member_remove subscriptions deploy together; there is
+    # no intermediate state where only one of the two is live.
     subjects:
       - lfx.fga-sync.update_access
       - lfx.fga-sync.delete_access

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -67,10 +67,9 @@ If no tuples are found:
 
 The FGA Sync service provides four universal NATS subjects that work with any
 resource type defined in the OpenFGA model, such as projects, committees, and
-v1 meetings. `update_access` and `delete_access` are asynchronous, ordered,
-at-least-once JetStream messages and never send application replies.
-`member_put` and `member_remove` remain core NATS operations that respond with
-`OK` after processing when a reply subject is provided.
+v1 meetings. All four — `update_access`, `delete_access`, `member_put`, and
+`member_remove` — are asynchronous, ordered, at-least-once JetStream messages
+and never send application replies.
 
 ### Benefits of Generic Handlers
 
@@ -494,7 +493,7 @@ msg := GenericFGAMessage{
 }
 
 payload, _ := json.Marshal(msg)
-nc.Request("lfx.fga-sync.member_put", payload, 5*time.Second)
+nc.Publish("lfx.fga-sync.member_put", payload)
 ```
 
 ---
@@ -609,7 +608,7 @@ msg := GenericFGAMessage{
 }
 
 payload, _ := json.Marshal(msg)
-nc.Request("lfx.fga-sync.member_remove", payload, 5*time.Second)
+nc.Publish("lfx.fga-sync.member_remove", payload)
 ```
 
 ---
@@ -806,18 +805,13 @@ Remove `attendee` if they didn't actually attend:
 
 ## Response Format
 
-`member_put` and `member_remove` return a simple `"OK"` string on success when
-the request includes a reply subject:
-
-```text
-OK
-```
-
-`update_access` and `delete_access` do not return `OK`. JetStream ACKs successful
-processing, redelivers transient failures, and terminates proven invalid
-payloads. Publishers receive no OpenFGA completion acknowledgement; `X-Sync`
-does not change that contract. Membership-operation failures are logged
-server-side and do not have a standardized NATS error response body.
+None of the four generic sync subjects (`update_access`, `delete_access`,
+`member_put`, `member_remove`) return an application reply. JetStream ACKs
+successful processing, redelivers transient failures, and terminates proven
+invalid payloads (missing `username`/`uid`, malformed JSON, wrong operation).
+Publishers receive no OpenFGA completion acknowledgement; `X-Sync` does not
+change that contract. Sync failures are logged server-side and do not have a
+standardized NATS error response body.
 
 The shared durable consumer normally preserves pending messages across service
 or NATS outages. If the durable consumer state itself is lost, fga-sync

--- a/docs/fga-sync-contract.md
+++ b/docs/fga-sync-contract.md
@@ -39,11 +39,13 @@ Membership delivery carries the same guarantees as access mutations: durable,
 at-least-once, ordered with the rest of the stream, and bounded to the retry
 ladder below before max-delivery exhaustion. A `member_put` or `member_remove`
 with a proven-invalid payload (missing `username`, missing `uid`, malformed
-JSON, wrong operation, or an empty relation entry in the array) is terminated
-immediately rather than retried; a terminated `member_remove` leaves the
-tuple(s) in place — fga-sync does not repair or retry on the publisher's
-behalf, and correcting the underlying data is the owning publisher's
-responsibility.
+JSON, or wrong operation) is terminated immediately rather than retried.
+`member_put` additionally terminates on an empty relation entry within the
+array; `member_remove` does not — it silently drops empty relation entries
+and, if none remain, removes all relations for that user (see the
+`relations` row below). A terminated `member_remove` leaves the tuple(s) in
+place — fga-sync does not repair or retry on the publisher's behalf, and
+correcting the underlying data is the owning publisher's responsibility.
 
 The durable consumer permits one globally pending message, attempts each
 message at most seven times, and uses `2m`, `2m`, `5m`, `10m`, `15m`, and `30m`
@@ -104,8 +106,10 @@ logs and `/debug/vars`.
 | --- | --- |
 | `username` missing/empty on `member_put` or `member_remove` | Terminated (proven invalid, not retried) |
 | `uid` missing/empty on any sync operation | Terminated (proven invalid, not retried) |
-| `relations` empty on `member_put` | Terminated (proven invalid, not retried) |
-| `relations` empty on `member_remove` | Removes ALL relations for that user (intentional) |
+| `relations` empty (`[]`) on `member_put` | Terminated (proven invalid, not retried) |
+| `relations` contains an empty string entry on `member_put` | Terminated (proven invalid, not retried) |
+| `relations` empty (`[]`) on `member_remove` | Removes ALL relations for that user (intentional) |
+| `relations` contains an empty string entry on `member_remove` | Entry is silently dropped; remaining non-empty relations are removed, or ALL relations if none remain |
 | `object_type` empty in envelope | Terminated (proven invalid, not retried) |
 | Unknown `operation` value | Terminated (proven invalid, not retried) |
 | `references` value with an empty `type` or empty `id` in `type:id` format | Message rejected |

--- a/docs/fga-sync-contract.md
+++ b/docs/fga-sync-contract.md
@@ -17,8 +17,8 @@ this service (`lfx-v2-fga-sync`).
 | --- | --- | --- |
 | `lfx.fga-sync.update_access` | Create/update access tuples for a resource | none; asynchronous |
 | `lfx.fga-sync.delete_access` | Delete publisher-managed tuples for a resource | none; asynchronous |
-| `lfx.fga-sync.member_put` | Add a user to a resource with one or more relations | `OK` on success if reply subject is provided |
-| `lfx.fga-sync.member_remove` | Remove specific or all relations for a user | `OK` on success if reply subject is provided |
+| `lfx.fga-sync.member_put` | Add a user to a resource with one or more relations | none; asynchronous |
+| `lfx.fga-sync.member_remove` | Remove specific or all relations for a user | none; asynchronous |
 | `lfx.access_check.request` | Batch authorization check (used by query-service) | text body |
 | `lfx.access_check.read_tuples` | Read all direct tuples for a user + object_type | JSON body |
 
@@ -26,14 +26,24 @@ Handlers are generic: **publishers do not need fga-sync code changes when adding
 new resource type that is defined in the OpenFGA model**. Use the generic
 envelope below.
 
-`update_access` and `delete_access` are persisted together in the
-`fga-sync-events` JetStream stream and consumed in one global order. Delivery is
-at least once: successful processing is ACKed, proven local validation failures
-are terminated, and every other error remains unacknowledged for bounded
-server-managed redelivery. Publishers must not use request/reply for these two
-subjects and an HTTP `X-Sync` option does not wait for OpenFGA convergence.
-`member_put`, `member_remove`, access checks, and tuple reads remain on core
-NATS.
+`update_access`, `delete_access`, `member_put`, and `member_remove` are
+persisted together in the `fga-sync-events` JetStream stream and consumed in
+one global order by a single shared durable consumer. Delivery is at least
+once: successful processing is ACKed, proven local validation failures are
+terminated, and every other error remains unacknowledged for bounded
+server-managed redelivery. Publishers must not use request/reply for any of
+these four subjects and an HTTP `X-Sync` option does not wait for OpenFGA
+convergence. Access checks and tuple reads remain on core NATS.
+
+Membership delivery carries the same guarantees as access mutations: durable,
+at-least-once, ordered with the rest of the stream, and bounded to the retry
+ladder below before max-delivery exhaustion. A `member_put` or `member_remove`
+with a proven-invalid payload (missing `username`, missing `uid`, malformed
+JSON, wrong operation, or an empty relation entry in the array) is terminated
+immediately rather than retried; a terminated `member_remove` leaves the
+tuple(s) in place — fga-sync does not repair or retry on the publisher's
+behalf, and correcting the underlying data is the owning publisher's
+responsibility.
 
 The durable consumer permits one globally pending message, attempts each
 message at most seven times, and uses `2m`, `2m`, `5m`, `10m`, `15m`, and `30m`
@@ -85,23 +95,22 @@ Examples:
 ### Tuple-format rejection conditions
 
 fga-sync rejects malformed envelopes before writing to OpenFGA, and the
-subscription loop logs the returned error. `update_access` and `delete_access`
-do not send application replies. Membership sync subjects only send `OK` after
-successful processing and do not currently send a standardized error reply
-body. Agents debugging missing access should inspect service logs and
-`/debug/vars`.
+subscription loop logs the returned error. None of the four generic sync
+subjects send application replies; JetStream ACK/terminate/redeliver is the
+only delivery signal. Agents debugging missing access should inspect service
+logs and `/debug/vars`.
 
 | Condition | Behavior |
 | --- | --- |
-| `username` missing/empty on `member_put` or `member_remove` | Message rejected |
-| `uid` missing/empty on any sync operation | Message rejected |
-| `relations` empty on `member_put` | Message rejected |
+| `username` missing/empty on `member_put` or `member_remove` | Terminated (proven invalid, not retried) |
+| `uid` missing/empty on any sync operation | Terminated (proven invalid, not retried) |
+| `relations` empty on `member_put` | Terminated (proven invalid, not retried) |
 | `relations` empty on `member_remove` | Removes ALL relations for that user (intentional) |
-| `object_type` empty in envelope | Message rejected |
-| Unknown `operation` value | Message rejected |
+| `object_type` empty in envelope | Terminated (proven invalid, not retried) |
+| Unknown `operation` value | Terminated (proven invalid, not retried) |
 | `references` value with an empty `type` or empty `id` in `type:id` format | Message rejected |
 | Tuple rejected by OpenFGA with `validation_error` | Invalid tuple is logged, removed from the batch, and the remaining batch is retried |
-| Non-validation OpenFGA write/read error | Operation fails and is logged |
+| Non-validation OpenFGA write/read error | Transient: message is left unacknowledged for redelivery, not terminated |
 
 ## Access Message Envelope: `GenericFGAMessage`
 
@@ -346,8 +355,12 @@ Common causes:
   publish errors).
 - Wrong `references` in the access message (wrong parent project UID).
 - User's LFID in the JWT doesn't match the username stored in the tuple.
-- Member payload was missing `username`. fga-sync rejects `member_put` and
-  `member_remove` when username is empty.
+- Member payload was missing `username` or `uid`. fga-sync terminates
+  `member_put` and `member_remove` immediately in this case rather than
+  retrying; a terminated message never reaches OpenFGA, so no tuple is
+  written or removed. Fixing the publisher and republishing corrected data is
+  the only recovery path — see LFXV2-2907 for the publisher-side root cause
+  and its ownership of the fix.
 - Cache is stale. Any successful OpenFGA write re-invalidates, or manually write to
   the `inv` KV key.
 

--- a/docs/runbooks/fga-sync-jetstream-cutover.md
+++ b/docs/runbooks/fga-sync-jetstream-cutover.md
@@ -3,10 +3,16 @@
 
 # FGA Sync JetStream Cutover and Rollback
 
-This runbook migrates `lfx.fga-sync.update_access` and
+## Phase 1: access mutations (`update_access` / `delete_access`)
+
+This section covers only Phase 1 — migrating `lfx.fga-sync.update_access` and
 `lfx.fga-sync.delete_access` together. Do not move only one subject: a delayed
 older update could otherwise recreate publisher-managed authorization after a
-newer deletion.
+newer deletion. **The purge step and the "consumer does not yet exist"
+precondition below are Phase 1-only** — they assume a clean cutover from a
+brand-new stream with no existing durable consumer. Phase 2 (below) adds
+`member_put`/`member_remove` to an already-live stream and consumer, so those
+steps do not apply and must not be repeated.
 
 ## Preconditions
 
@@ -95,6 +101,96 @@ Fallback when the consumer cannot drain safely:
 Never release the maintenance window with undispositioned durable messages.
 Never blindly replay retained payloads: an old full-state update can overwrite a
 newer update or recreate publisher-managed authorization after deletion.
+
+## Phase 2: membership (`member_put` / `member_remove`)
+
+Phase 2 moves `lfx.fga-sync.member_put` and `lfx.fga-sync.member_remove` onto
+the same stream and shared durable consumer as Phase 1, in three ordered
+releases. Unlike Phase 1, the stream and consumer already exist and are live;
+there is no fresh-stream purge and no "consumer does not yet exist"
+precondition. Do not reuse the Phase 1 cutover steps above for this phase.
+
+### Preconditions (release 2 gate)
+
+Before release 2 (stream widening), confirm all four owning publisher services
+— project-service, committee-service, meeting-service, and member-service —
+are asynchronous-only (`Publish`, never `Request`/`Reply`) for `member_put` and
+`member_remove`. This must be verified per-service because widening the
+stream, not removing the core subscription, is the actual point of no return
+for a request/reply caller: the moment membership subjects join the stream,
+the stream acknowledges the publish and a surviving `nc.Request` caller reads
+that JetStream storage ack as completion, even though fga-sync has not
+processed the message yet and core subscription removal (release 3) has not
+happened. Also confirm the release-1 shared-consumer binary (with
+`FilterSubjects` covering all four subjects and the write-collision-ignore
+options) is fully rolled out and confirmed live first.
+
+### The three ordered releases
+
+1. **Release 1 — shared consumer code.** Deploy the fga-sync binary that
+   dispatches `member_put`/`member_remove` through the shared JetStream
+   consumer and passes `on_duplicate: ignore` / `on_missing: ignore` to
+   OpenFGA writes. At this point membership subjects are still core NATS only
+   (not yet in the stream), so this release is inert for membership traffic.
+2. **Release 2 — stream widening.** Add `lfx.fga-sync.member_put` and
+   `lfx.fga-sync.member_remove` to the stream's `subjects` list via the Helm
+   chart. From this point until release 3, every membership message is
+   delivered twice: once via the pre-existing core NATS subscription (still
+   running) and once via the JetStream consumer.
+3. **Release 3 — core subscription removal.** Remove the core NATS
+   subscriptions for `member_put`/`member_remove` so JetStream is the only
+   delivery path. Do not deploy this release before release 2 has been
+   applied and verified: doing so briefly removes the *only* delivery path
+   for membership messages (core), before the stream capture that would carry
+   them, and those messages are lost permanently.
+
+### The overlap window (between release 2 and release 3)
+
+During the overlap window, expect **each membership message applied twice —
+but no collision errors**, because `on_duplicate: ignore` / `on_missing:
+ignore` (shipped in release 1 as part of write-collision handling) makes the
+second application a no-op rather than a write error. Concretely:
+
+- A duplicate `member_put` re-adds the same relation tuple; OpenFGA reports
+  success on the redundant write instead of a duplicate-write error.
+- A duplicate `member_remove` re-deletes an already-removed relation tuple;
+  OpenFGA reports success on the redundant delete instead of a missing-tuple
+  error.
+
+If a collision-driven error burst appears instead, the write-collision-ignore
+options from release 1 are not in effect — treat that as a signal to remove
+the stream subjects (roll back release 2) rather than riding out the window.
+Keep the window short and attended: membership arrives at roughly 2.25
+messages per minute, so an unattended window accumulates duplicate work
+quickly. Watch consumer ack lag for the whole window, not just at the end;
+rising ack lag is the signal to proceed to release 3 immediately or roll back.
+
+### Post-cutover checks (Phase 2)
+
+- `sync_terminal` rises to a new floor once membership's proven-invalid
+  payloads (missing `username`/`uid`, malformed JSON, wrong operation, empty
+  relation entries) start terminating through the shared consumer instead of
+  being silently dropped by the old core handler. **This floor increase is
+  expected** and traces to LFXV2-2907 publisher-side payload gaps — do not
+  read it as a fga-sync regression.
+- After release 3, confirm double processing has stopped: each membership
+  message is applied once, and `sync_terminal`'s membership contribution
+  matches the LFXV2-2907 rate rather than twice it (the release-2 overlap
+  rate).
+- A terminated `member_remove` leaves the tuple(s) in place — fga-sync does
+  not retry or repair on the publisher's behalf. Attribution and repair of a
+  terminated message belong to the owning publisher, not to a fga-sync
+  operator action.
+
+### Rollback (Phase 2)
+
+Restoring the core subscriptions after release 3 recreates the overlap
+window described above (double delivery, no-op collisions) — this is
+expected and safe on its own. The unsafe action is blindly replaying retained
+JetStream membership payloads after a rollback: retained pre-rollback history
+can be stale relative to what the restored core path has since processed, so
+never replay it wholesale. If specific membership state is suspect, have the
+owning service re-read current database state and republish.
 
 ## Consumer state loss (disaster recovery)
 

--- a/docs/runbooks/fga-sync-jetstream-cutover.md
+++ b/docs/runbooks/fga-sync-jetstream-cutover.md
@@ -157,16 +157,48 @@ same way Phase 1's cutover is verified above. Do not treat the deploy as
 successful until that check has been done; there is no automated gate doing
 it for you.
 
-### The no-op guarantee, for the rollback case
+### Rolling-upgrade pod version skew
+
+The consumer-plus-chart bundling above assumes the deploy is instantaneous.
+It is not: prod runs 3 replicas (PDB `minAvailable: 2`) and staging runs 2
+(PDB `minAvailable: 1`), on Kubernetes' default `RollingUpdate` strategy —
+there is no `Recreate` override anywhere in this chart or in the
+environment-specific `lfx-v2-argocd` values. A new pod is started and must
+become healthy before an old one is stopped, so for the practical duration of
+every rollout (observed as roughly the time for each pod to cycle,
+one-at-a-time, times the replica count), old-binary and new-binary pods are
+both running.
+
+This matters because the durable consumer's `FilterSubjects` is shared,
+server-side state, not per-pod: the instant the *first* new pod calls
+`CreateOrUpdateConsumer` on startup (`access_mutation.go`), the durable
+widens for every pod pulling from it, including old pods still running the
+previous binary. The old binary's `dispatchAccessMutation` switch has no case
+for `member_put`/`member_remove` and falls through to
+`newTerminalValidationError` for any unrecognized subject — so if an old pod
+happens to pull a newly-admitted membership message during that window, it
+terminates a perfectly valid message. Old pods also keep their core-NATS
+subscriptions active until they actually stop, so the core-vs-JetStream
+double-delivery window described below also reappears transiently during
+every rollout of this change, not only during an explicit rollback.
+
+**Mitigation:** watch the rollout manually (`kubectl get pods -o wide` with
+the image tag, or the equivalent ArgoCD view) and do not treat the deploy as
+finished until every pod reports the new image. If an old pod is slow to
+terminate, delete it manually rather than waiting for a graceful drain, to
+shrink the coexistence window. This is an accepted, monitored risk, not a
+solved one: a message terminated during this specific window is lost the
+same way any other terminated message is (see "Post-cutover checks" above),
+and the owning publisher would need to notice and republish.
+
+### The no-op guarantee, for rollback and rolling-upgrade skew
 
 `on_duplicate: ignore` / `on_missing: ignore` (write-collision handling)
-exists primarily for the rollback path, not for a normal deploy: a normal
-deploy has no window where the same membership message is delivered via both
-core and JetStream, because core disappears in the same step the stream
-widens. The window this guards against arises if the core subscriptions are
-*restored* later (see "Rollback" below), which recreates double delivery
-against a stream that is still widened. During that restored-core window,
-expect **each membership message applied twice — but no collision errors**,
+covers two windows, not one: the rolling-upgrade skew above, and an explicit
+rollback that restores core subscriptions while the stream is still widened
+(see "Rollback" below). Both recreate the same double-delivery shape. During
+either window, expect **each membership message applied twice — but no
+collision errors**,
 because the no-op options make the second application a no-op rather than a
 write error. Concretely:
 
@@ -186,8 +218,9 @@ so an unattended window accumulates duplicate work quickly.
 `on_missing: ignore` only make an *exact-match* redundant write or delete a
 no-op — the same tuple applied twice ends up in the same state either way.
 They do not impose any ordering between two *different* messages for the same
-user/object. If core subscriptions are ever restored while the stream is
-still widened (the rollback scenario), the core path is not serialized by the
+user/object. Whenever core subscriptions are active while the stream is
+widened — during rolling-upgrade skew or after a rollback — the core path is
+not serialized by the
 JetStream consumer's `MaxAckPending: 1`, so an older `member_put` delivered
 via core can finish after the JetStream consumer has already applied that
 same put and a subsequent `member_remove` or `delete_access`. In that case

--- a/docs/runbooks/fga-sync-jetstream-cutover.md
+++ b/docs/runbooks/fga-sync-jetstream-cutover.md
@@ -165,18 +165,39 @@ messages per minute, so an unattended window accumulates duplicate work
 quickly. Watch consumer ack lag for the whole window, not just at the end;
 rising ack lag is the signal to proceed to release 3 immediately or roll back.
 
+**What the no-op guarantee does and does not cover.** `on_duplicate: ignore` /
+`on_missing: ignore` only make an *exact-match* redundant write or delete a
+no-op — the same tuple applied twice ends up in the same state either way.
+They do not impose any ordering between two *different* messages for the same
+user/object. The core path is not serialized by the JetStream consumer's
+`MaxAckPending: 1`, so an older `member_put` delivered via core can finish
+after the JetStream consumer has already applied that same put and a
+subsequent `member_remove` or `delete_access`. In that case the tuple is
+absent when the late core `member_put` runs, so it is a legitimate write
+rather than a duplicate, and it recreates access the newer message removed.
+This residual reordering risk is not closed by this change and is bounded
+only by keeping the window short and watching for it, not eliminated. If a
+suspiciously recent grant reappears on an object with intervening membership
+or deletion activity, treat it as this scenario and have the owning service
+re-read current state and republish rather than assuming it is legitimate.
+
 ### Post-cutover checks (Phase 2)
 
 - `sync_terminal` rises to a new floor once membership's proven-invalid
-  payloads (missing `username`/`uid`, malformed JSON, wrong operation, empty
-  relation entries) start terminating through the shared consumer instead of
-  being silently dropped by the old core handler. **This floor increase is
-  expected** and traces to LFXV2-2907 publisher-side payload gaps — do not
-  read it as a fga-sync regression.
-- After release 3, confirm double processing has stopped: each membership
-  message is applied once, and `sync_terminal`'s membership contribution
-  matches the LFXV2-2907 rate rather than twice it (the release-2 overlap
-  rate).
+  payloads (missing `username`/`uid`, malformed JSON, wrong operation, or an
+  empty relation entry on `member_put` specifically — `member_remove` drops
+  empty relation entries rather than terminating on them) start terminating
+  through the shared consumer instead of being silently dropped by the old
+  core handler. **This floor increase is expected** and traces to LFXV2-2907
+  publisher-side payload gaps — do not read it as a fga-sync regression.
+- `sync_terminal` does **not** double during the release-2 overlap window:
+  the core-path handler only logs its error and does not touch this counter,
+  so only the JetStream-side termination increments it, both during and
+  after release 3. It is therefore not a usable signal for confirming double
+  processing has stopped. To confirm that, compare OpenFGA write/delete
+  volume (or handler-invocation logs) for membership objects before and
+  after release 3 instead — it should roughly halve once the core path is
+  removed.
 - A terminated `member_remove` leaves the tuple(s) in place — fga-sync does
   not retry or repair on the publisher's behalf. Attribution and repair of a
   terminated message belong to the owning publisher, not to a fga-sync
@@ -185,12 +206,14 @@ rising ack lag is the signal to proceed to release 3 immediately or roll back.
 ### Rollback (Phase 2)
 
 Restoring the core subscriptions after release 3 recreates the overlap
-window described above (double delivery, no-op collisions) — this is
-expected and safe on its own. The unsafe action is blindly replaying retained
-JetStream membership payloads after a rollback: retained pre-rollback history
-can be stale relative to what the restored core path has since processed, so
-never replay it wholesale. If specific membership state is suspect, have the
-owning service re-read current database state and republish.
+window described above, including its residual reordering risk (see "What
+the no-op guarantee does and does not cover" above) — this is expected, not
+a new failure mode introduced by rollback. The unsafe action is blindly
+replaying retained JetStream membership payloads after a rollback: retained
+pre-rollback history can be stale relative to what the restored core path
+has since processed, so never replay it wholesale. If specific membership
+state is suspect, have the owning service re-read current database state and
+republish.
 
 ## Consumer state loss (disaster recovery)
 

--- a/docs/runbooks/fga-sync-jetstream-cutover.md
+++ b/docs/runbooks/fga-sync-jetstream-cutover.md
@@ -105,51 +105,70 @@ newer update or recreate publisher-managed authorization after deletion.
 ## Phase 2: membership (`member_put` / `member_remove`)
 
 Phase 2 moves `lfx.fga-sync.member_put` and `lfx.fga-sync.member_remove` onto
-the same stream and shared durable consumer as Phase 1, in three ordered
-releases. Unlike Phase 1, the stream and consumer already exist and are live;
-there is no fresh-stream purge and no "consumer does not yet exist"
-precondition. Do not reuse the Phase 1 cutover steps above for this phase.
+the same stream and shared durable consumer as Phase 1. Unlike Phase 1, the
+stream and consumer already exist and are live; there is no fresh-stream
+purge and no "consumer does not yet exist" precondition. Do not reuse the
+Phase 1 cutover steps above for this phase.
 
-### Preconditions (release 2 gate)
+### Deployment shape: one combined release, not three
 
-Before release 2 (stream widening), confirm all four owning publisher services
-— project-service, committee-service, meeting-service, and member-service —
-are asynchronous-only (`Publish`, never `Request`/`Reply`) for `member_put` and
-`member_remove`. This must be verified per-service because widening the
-stream, not removing the core subscription, is the actual point of no return
-for a request/reply caller: the moment membership subjects join the stream,
-the stream acknowledges the publish and a surviving `nc.Request` caller reads
-that JetStream storage ack as completion, even though fga-sync has not
-processed the message yet and core subscription removal (release 3) has not
-happened. Also confirm the release-1 shared-consumer binary (with
-`FilterSubjects` covering all four subjects and the write-collision-ignore
-options) is fully rolled out and confirmed live first.
+The fga-sync-jetstream-membership change ships the shared-consumer code, the
+Helm stream-widening (adding `member_put`/`member_remove` to the stream's
+`subjects`), and the core-subscription removal in the same binary and chart
+version — they deploy together as a single `helm upgrade`, not as three
+separately-timed releases. This means the moment the new version is live: the
+stream is already widened and the old core subscriptions are already gone,
+with no observable window in between where only one of the two has happened.
 
-### The three ordered releases
+This trades a design goal (verify stream-widening is capturing traffic before
+removing the fallback) for simplicity: there is no core-NATS fallback the
+instant this deploys, and no scripted gate confirms the stream capture
+succeeded before that happens. That risk is accepted deliberately — see
+"Accepted risk" below — rather than mitigated by splitting the rollout.
 
-1. **Release 1 — shared consumer code.** Deploy the fga-sync binary that
-   dispatches `member_put`/`member_remove` through the shared JetStream
-   consumer and passes `on_duplicate: ignore` / `on_missing: ignore` to
-   OpenFGA writes. At this point membership subjects are still core NATS only
-   (not yet in the stream), so this release is inert for membership traffic.
-2. **Release 2 — stream widening.** Add `lfx.fga-sync.member_put` and
-   `lfx.fga-sync.member_remove` to the stream's `subjects` list via the Helm
-   chart. From this point until release 3, every membership message is
-   delivered twice: once via the pre-existing core NATS subscription (still
-   running) and once via the JetStream consumer.
-3. **Release 3 — core subscription removal.** Remove the core NATS
-   subscriptions for `member_put`/`member_remove` so JetStream is the only
-   delivery path. Do not deploy this release before release 2 has been
-   applied and verified: doing so briefly removes the *only* delivery path
-   for membership messages (core), before the stream capture that would carry
-   them, and those messages are lost permanently.
+### Preconditions
 
-### The overlap window (between release 2 and release 3)
+Before deploying this change to an environment, confirm both:
 
-During the overlap window, expect **each membership message applied twice —
-but no collision errors**, because `on_duplicate: ignore` / `on_missing:
-ignore` (shipped in release 1 as part of write-collision handling) makes the
-second application a no-op rather than a write error. Concretely:
+1. All four owning publisher services — committee-service, meeting-service,
+   mailing-list-service, and member-service — are asynchronous-only
+   (`Publish`, never `Request`/`Reply`) for `member_put` and `member_remove`,
+   and that deployment is live in that environment. Project-service only
+   issues `update_access`/`delete_access` and is not affected. This must be
+   verified per-service: the moment membership subjects join the stream, the
+   stream acknowledges the publish and a surviving `nc.Request` caller reads
+   that JetStream storage ack as completion, even though fga-sync has not
+   actually processed the message yet.
+2. Phase 1 (`update_access`/`delete_access` on JetStream) has been live and
+   stable in that environment for a soak period, since Phase 2 shares the
+   same stream and durable consumer and a Phase 1 regression would now also
+   affect membership traffic.
+
+### Accepted risk: no verification pause before the core fallback disappears
+
+Because stream-widening and core-subscription-removal land in the same
+deploy, if the widened stream silently fails to capture membership traffic
+(a Helm value not applied, a replica still on old config, a consumer
+`FilterSubjects` mismatch), there is no fallback path left to catch those
+messages — core no longer has a subscription for them. Immediately after
+deploying, manually check that `sync_ack` is increasing and
+`sync_max_deliver_exhausted` is not (see "Post-cutover checks" below), the
+same way Phase 1's cutover is verified above. Do not treat the deploy as
+successful until that check has been done; there is no automated gate doing
+it for you.
+
+### The no-op guarantee, for the rollback case
+
+`on_duplicate: ignore` / `on_missing: ignore` (write-collision handling)
+exists primarily for the rollback path, not for a normal deploy: a normal
+deploy has no window where the same membership message is delivered via both
+core and JetStream, because core disappears in the same step the stream
+widens. The window this guards against arises if the core subscriptions are
+*restored* later (see "Rollback" below), which recreates double delivery
+against a stream that is still widened. During that restored-core window,
+expect **each membership message applied twice — but no collision errors**,
+because the no-op options make the second application a no-op rather than a
+write error. Concretely:
 
 - A duplicate `member_put` re-adds the same relation tuple; OpenFGA reports
   success on the redundant write instead of a duplicate-write error.
@@ -158,31 +177,34 @@ second application a no-op rather than a write error. Concretely:
   error.
 
 If a collision-driven error burst appears instead, the write-collision-ignore
-options from release 1 are not in effect — treat that as a signal to remove
-the stream subjects (roll back release 2) rather than riding out the window.
-Keep the window short and attended: membership arrives at roughly 2.25
-messages per minute, so an unattended window accumulates duplicate work
-quickly. Watch consumer ack lag for the whole window, not just at the end;
-rising ack lag is the signal to proceed to release 3 immediately or roll back.
+options are not in effect — treat that as a signal to roll back (see
+"Rollback" below) rather than riding out the window. Keep any such window
+short and attended: membership arrives at roughly 2.25 messages per minute,
+so an unattended window accumulates duplicate work quickly.
 
 **What the no-op guarantee does and does not cover.** `on_duplicate: ignore` /
 `on_missing: ignore` only make an *exact-match* redundant write or delete a
 no-op — the same tuple applied twice ends up in the same state either way.
 They do not impose any ordering between two *different* messages for the same
-user/object. The core path is not serialized by the JetStream consumer's
-`MaxAckPending: 1`, so an older `member_put` delivered via core can finish
-after the JetStream consumer has already applied that same put and a
-subsequent `member_remove` or `delete_access`. In that case the tuple is
-absent when the late core `member_put` runs, so it is a legitimate write
-rather than a duplicate, and it recreates access the newer message removed.
-This residual reordering risk is not closed by this change and is bounded
-only by keeping the window short and watching for it, not eliminated. If a
-suspiciously recent grant reappears on an object with intervening membership
-or deletion activity, treat it as this scenario and have the owning service
-re-read current state and republish rather than assuming it is legitimate.
+user/object. If core subscriptions are ever restored while the stream is
+still widened (the rollback scenario), the core path is not serialized by the
+JetStream consumer's `MaxAckPending: 1`, so an older `member_put` delivered
+via core can finish after the JetStream consumer has already applied that
+same put and a subsequent `member_remove` or `delete_access`. In that case
+the tuple is absent when the late core `member_put` runs, so it is a
+legitimate write rather than a duplicate, and it recreates access the newer
+message removed. This residual reordering risk is not closed by this change
+and is bounded only by keeping any restored-core window short and watching
+for it, not eliminated. If a suspiciously recent grant reappears on an object
+with intervening membership or deletion activity, treat it as this scenario
+and have the owning service re-read current state and republish rather than
+assuming it is legitimate.
 
 ### Post-cutover checks (Phase 2)
 
+- `sync_ack` should increase and `sync_max_deliver_exhausted` should not,
+  within minutes of the deploy (see "Accepted risk" above) — do this check
+  manually right after deploying, the same way Phase 1's cutover is checked.
 - `sync_terminal` rises to a new floor once membership's proven-invalid
   payloads (missing `username`/`uid`, malformed JSON, wrong operation, or an
   empty relation entry on `member_put` specifically — `member_remove` drops
@@ -190,14 +212,6 @@ re-read current state and republish rather than assuming it is legitimate.
   through the shared consumer instead of being silently dropped by the old
   core handler. **This floor increase is expected** and traces to LFXV2-2907
   publisher-side payload gaps — do not read it as a fga-sync regression.
-- `sync_terminal` does **not** double during the release-2 overlap window:
-  the core-path handler only logs its error and does not touch this counter,
-  so only the JetStream-side termination increments it, both during and
-  after release 3. It is therefore not a usable signal for confirming double
-  processing has stopped. To confirm that, compare OpenFGA write/delete
-  volume (or handler-invocation logs) for membership objects before and
-  after release 3 instead — it should roughly halve once the core path is
-  removed.
 - A terminated `member_remove` leaves the tuple(s) in place — fga-sync does
   not retry or repair on the publisher's behalf. Attribution and repair of a
   terminated message belong to the owning publisher, not to a fga-sync
@@ -205,15 +219,15 @@ re-read current state and republish rather than assuming it is legitimate.
 
 ### Rollback (Phase 2)
 
-Restoring the core subscriptions after release 3 recreates the overlap
-window described above, including its residual reordering risk (see "What
-the no-op guarantee does and does not cover" above) — this is expected, not
-a new failure mode introduced by rollback. The unsafe action is blindly
-replaying retained JetStream membership payloads after a rollback: retained
-pre-rollback history can be stale relative to what the restored core path
-has since processed, so never replay it wholesale. If specific membership
-state is suspect, have the owning service re-read current database state and
-republish.
+Restoring the core subscriptions after this change is live recreates the
+overlap window described above, including its residual reordering risk (see
+"What the no-op guarantee does and does not cover" above) — this is
+expected, not a new failure mode introduced by rollback. The unsafe action is
+blindly replaying retained JetStream membership payloads after a rollback:
+retained pre-rollback history can be stale relative to what the restored
+core path has since processed, so never replay it wholesale. If specific
+membership state is suspect, have the owning service re-read current
+database state and republish.
 
 ## Consumer state loss (disaster recovery)
 

--- a/fga.go
+++ b/fga.go
@@ -483,6 +483,21 @@ func (s FgaService) WriteAndDeleteTuples(
 	return skippedWrites, nil
 }
 
+// writeCollisionIgnoreOptions instructs OpenFGA to treat a write of an
+// already-existing tuple, or a delete of an already-absent tuple, as a
+// server-side no-op instead of a failed transaction. Both fields must be set
+// together: a request mixing ignore and error semantics reverts to error for
+// the whole request, so setting only one has no effect on a batch carrying
+// both writes and deletes. This applies to every writeAndDeleteTuplesBatch
+// call, including the two Phase 1 access subjects, because the same
+// collision can occur on a retry after a partially applied batch.
+var writeCollisionIgnoreOptions = ClientWriteOptions{
+	Conflict: ClientWriteConflictOptions{
+		OnDuplicateWrites: CLIENT_WRITE_REQUEST_ON_DUPLICATE_WRITES_IGNORE,
+		OnMissingDeletes:  CLIENT_WRITE_REQUEST_ON_MISSING_DELETES_IGNORE,
+	},
+}
+
 // writeAndDeleteTuplesBatch performs a single write/delete operation to OpenFGA.
 // If OpenFGA returns a validation_error for an invalid tuple, that tuple is
 // removed and the batch is retried with the remaining tuples. It returns the
@@ -502,7 +517,7 @@ func (s FgaService) writeAndDeleteTuplesBatch(
 			Deletes: deletes,
 		}
 
-		_, err := s.client.Write(ctx, req)
+		_, err := s.client.Write(ctx, req, writeCollisionIgnoreOptions)
 		if err != nil {
 			tupleStr, ok := extractInvalidTuple(err)
 			if !ok {

--- a/fga_cache_test.go
+++ b/fga_cache_test.go
@@ -48,7 +48,7 @@ func TestSyncObjectTuplesSeedsPositiveCacheOnlyAfterSuccessfulWrite(t *testing.T
 				On("Read", mock.Anything, mock.Anything, client.ClientReadOptions{}).
 				Return(&client.ClientReadResponse{}, nil)
 			fgaClient.
-				On("Write", mock.Anything, mock.Anything).
+				On("Write", mock.Anything, mock.Anything, mock.Anything).
 				Return(&client.ClientWriteResponse{}, tt.writeErr)
 			cache := &cacheWriteRecorder{writes: make(chan string, 1)}
 			service := FgaService{client: fgaClient, cacheBucket: cache}
@@ -93,7 +93,7 @@ func TestSyncObjectTuplesDoesNotSeedCacheForTupleSkippedDuringInvalidTupleRetry(
 	fgaClient.
 		On("Write", mock.Anything, mock.MatchedBy(func(req client.ClientWriteRequest) bool {
 			return len(req.Writes) == 2
-		})).
+		}), mock.Anything).
 		Return((*client.ClientWriteResponse)(nil), makeValidationError(
 			"Invalid tuple 'project:resource-1#writer@user:alice'. Reason: relation 'project#writer' not found",
 		)).
@@ -102,7 +102,7 @@ func TestSyncObjectTuplesDoesNotSeedCacheForTupleSkippedDuringInvalidTupleRetry(
 	fgaClient.
 		On("Write", mock.Anything, mock.MatchedBy(func(req client.ClientWriteRequest) bool {
 			return len(req.Writes) == 1 && req.Writes[0].User == "user:bob"
-		})).
+		}), mock.Anything).
 		Return(&client.ClientWriteResponse{}, nil).
 		Once()
 

--- a/fga_client.go
+++ b/fga_client.go
@@ -15,7 +15,7 @@ import (
 // IFgaClient is an interface for OpenFGA client operations used in this service.
 type IFgaClient interface {
 	Read(ctx context.Context, req ClientReadRequest, options ClientReadOptions) (*ClientReadResponse, error)
-	Write(ctx context.Context, req ClientWriteRequest) (*ClientWriteResponse, error)
+	Write(ctx context.Context, req ClientWriteRequest, options ClientWriteOptions) (*ClientWriteResponse, error)
 	BatchCheck(ctx context.Context, request ClientBatchCheckRequest) (*openfga.BatchCheckResponse, error)
 	ListObjects(
 		ctx context.Context,
@@ -50,8 +50,9 @@ func (c FgaAdapter) Read(
 func (c FgaAdapter) Write(
 	ctx context.Context,
 	req ClientWriteRequest,
+	options ClientWriteOptions,
 ) (*ClientWriteResponse, error) {
-	return c.OpenFgaClient.Write(ctx).Body(req).Execute()
+	return c.OpenFgaClient.Write(ctx).Body(req).Options(options).Execute()
 }
 
 // ListObjects executes a list objects request.

--- a/fga_otel_test.go
+++ b/fga_otel_test.go
@@ -116,7 +116,7 @@ func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
 				mc := new(MockFgaClient)
 				// fakeStatusErr{code:500} is not a validation error, so the retry
 				// path is not taken and the error is returned immediately.
-				mc.On("Write", mock.Anything, mock.Anything).
+				mc.On("Write", mock.Anything, mock.Anything, mock.Anything).
 					Return((*ClientWriteResponse)(nil), fakeStatusErr{code: 500})
 				return FgaService{client: mc}
 			},
@@ -194,7 +194,7 @@ func TestFgaService_RecordsErrorOnSpan(t *testing.T) {
 			wantSpan: false,
 			setup: func() FgaService {
 				mc := new(MockFgaClient)
-				mc.On("Write", mock.Anything, mock.Anything).
+				mc.On("Write", mock.Anything, mock.Anything, mock.Anything).
 					Return((*ClientWriteResponse)(nil), fakeStatusErr{code: 422})
 				return FgaService{client: mc}
 			},

--- a/fga_test.go
+++ b/fga_test.go
@@ -944,7 +944,7 @@ func TestDeleteTuplesByUserAndObject(t *testing.T) {
 						req.Deletes[0].User == "user:123" &&
 						req.Deletes[0].Relation == "participant" &&
 						req.Deletes[0].Object == "meeting:456"
-				})).Return(&ClientWriteResponse{}, nil).Once()
+				}), mock.Anything).Return(&ClientWriteResponse{}, nil).Once()
 			},
 			expectError: false,
 			description: "should delete single tuple for user on object",
@@ -988,7 +988,7 @@ func TestDeleteTuplesByUserAndObject(t *testing.T) {
 						relations[del.Relation] = true
 					}
 					return relations["host"] && relations["invitee"] && relations["attendee"]
-				})).Return(&ClientWriteResponse{}, nil).Once()
+				}), mock.Anything).Return(&ClientWriteResponse{}, nil).Once()
 			},
 			expectError: false,
 			description: "should delete all tuples for user on object",
@@ -1043,7 +1043,7 @@ func TestDeleteTuplesByUserAndObject(t *testing.T) {
 				}, nil).Once()
 
 				// Mock DeleteTuples to return an error
-				m.On("Write", mock.Anything, mock.Anything).
+				m.On("Write", mock.Anything, mock.Anything, mock.Anything).
 					Return((*ClientWriteResponse)(nil), errors.New("delete error")).Once()
 			},
 			expectError: true,
@@ -1080,7 +1080,7 @@ func TestDeleteTuplesByUserAndObject(t *testing.T) {
 					return len(req.Deletes) == 2 &&
 						req.Deletes[0].User == "user:paginated" &&
 						req.Deletes[1].User == "user:paginated"
-				})).Return(&ClientWriteResponse{}, nil).Once()
+				}), mock.Anything).Return(&ClientWriteResponse{}, nil).Once()
 			},
 			expectError: false,
 			description: "should handle paginated results when reading tuples",
@@ -1375,7 +1375,7 @@ func TestSyncObjectTuples_ExcludeRelations(t *testing.T) {
 					writesCount := len(req.Writes)
 					deletesCount := len(req.Deletes)
 					return writesCount == tt.expectedWrites && deletesCount == tt.expectedDeletes
-				}), mock.Anything).Return((*ClientWriteResponse)(nil), nil).Once()
+				}), mock.Anything, mock.Anything).Return((*ClientWriteResponse)(nil), nil).Once()
 			}
 
 			// Create mock cache bucket
@@ -1519,7 +1519,7 @@ func TestSyncObjectTuples_PreserveTeamGrants(t *testing.T) {
 						}
 					}
 					return true
-				}), mock.Anything).Return((*ClientWriteResponse)(nil), nil).Once()
+				}), mock.Anything, mock.Anything).Return((*ClientWriteResponse)(nil), nil).Once()
 			}
 
 			mockCache := new(MockNatsKeyValue)
@@ -1585,13 +1585,13 @@ func TestWriteAndDeleteTuplesBatch(t *testing.T) {
 				// First call fails with invalid tuple error for executive_director
 				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
 					return len(req.Writes) == 2
-				})).Return((*ClientWriteResponse)(nil),
+				}), mock.Anything).Return((*ClientWriteResponse)(nil),
 					makeValidationError("Invalid tuple 'project:5e88f157#executive_director@user:alice'. Reason: relation 'project#executive_director' not found"),
 				).Once()
 				// Retry with only the valid tuple succeeds
 				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
 					return len(req.Writes) == 1 && req.Writes[0].Relation == "viewer"
-				})).Return(&ClientWriteResponse{}, nil).Once()
+				}), mock.Anything).Return(&ClientWriteResponse{}, nil).Once()
 			},
 			expectError: false,
 			wantSkipped: []string{"project:5e88f157#executive_director@user:alice"},
@@ -1608,13 +1608,13 @@ func TestWriteAndDeleteTuplesBatch(t *testing.T) {
 				// First call fails with invalid tuple error
 				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
 					return len(req.Deletes) == 2
-				})).Return((*ClientWriteResponse)(nil),
+				}), mock.Anything).Return((*ClientWriteResponse)(nil),
 					makeValidationError("Invalid tuple 'vote_response:abc#project@project:123'. Reason: relation 'vote_response#project' not found"),
 				).Once()
 				// Retry with only the valid delete tuple succeeds
 				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
 					return len(req.Deletes) == 1 && req.Deletes[0].Relation == "viewer"
-				})).Return(&ClientWriteResponse{}, nil).Once()
+				}), mock.Anything).Return(&ClientWriteResponse{}, nil).Once()
 			},
 			expectError: false,
 			description: "invalid delete tuple should be removed and batch retried",
@@ -1626,7 +1626,7 @@ func TestWriteAndDeleteTuplesBatch(t *testing.T) {
 			},
 			deletes: nil,
 			mockSetup: func(m *MockFgaClient) {
-				m.On("Write", mock.Anything, mock.Anything).Return((*ClientWriteResponse)(nil),
+				m.On("Write", mock.Anything, mock.Anything, mock.Anything).Return((*ClientWriteResponse)(nil),
 					makeValidationError("Invalid tuple 'project:123#executive_director@user:alice'. Reason: relation 'project#executive_director' not found"),
 				).Once()
 			},
@@ -1641,7 +1641,7 @@ func TestWriteAndDeleteTuplesBatch(t *testing.T) {
 			},
 			deletes: nil,
 			mockSetup: func(m *MockFgaClient) {
-				m.On("Write", mock.Anything, mock.Anything).
+				m.On("Write", mock.Anything, mock.Anything, mock.Anything).
 					Return((*ClientWriteResponse)(nil), errors.New("network error")).Once()
 			},
 			expectError: true,
@@ -1659,19 +1659,19 @@ func TestWriteAndDeleteTuplesBatch(t *testing.T) {
 				// First call: 3 writes, fail on executive_director
 				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
 					return len(req.Writes) == 3
-				})).Return((*ClientWriteResponse)(nil),
+				}), mock.Anything).Return((*ClientWriteResponse)(nil),
 					makeValidationError("Invalid tuple 'project:abc#executive_director@user:alice'. Reason: relation 'project#executive_director' not found"),
 				).Once()
 				// Second call: 2 writes, fail on technical_advisor
 				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
 					return len(req.Writes) == 2
-				})).Return((*ClientWriteResponse)(nil),
+				}), mock.Anything).Return((*ClientWriteResponse)(nil),
 					makeValidationError("Invalid tuple 'project:abc#technical_advisor@user:bob'. Reason: relation 'project#technical_advisor' not found"),
 				).Once()
 				// Third call: 1 write (viewer), succeeds
 				m.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
 					return len(req.Writes) == 1 && req.Writes[0].Relation == "viewer"
-				})).Return(&ClientWriteResponse{}, nil).Once()
+				}), mock.Anything).Return(&ClientWriteResponse{}, nil).Once()
 			},
 			expectError: false,
 			wantSkipped: []string{
@@ -1706,4 +1706,59 @@ func TestWriteAndDeleteTuplesBatch(t *testing.T) {
 			mockClient.AssertExpectations(t)
 		})
 	}
+}
+
+// TestWriteCollisionIgnoreOptions asserts that the collision options value
+// sets both OnDuplicateWrites and OnMissingDeletes to ignore. Per D15, a
+// request mixing ignore and error semantics reverts to error for the whole
+// request, so both fields must be set together.
+func TestWriteCollisionIgnoreOptions(t *testing.T) {
+	options := writeCollisionIgnoreOptions
+
+	assert.Equal(t, CLIENT_WRITE_REQUEST_ON_DUPLICATE_WRITES_IGNORE, options.Conflict.OnDuplicateWrites)
+	assert.Equal(t, CLIENT_WRITE_REQUEST_ON_MISSING_DELETES_IGNORE, options.Conflict.OnMissingDeletes)
+}
+
+// TestWriteAndDeleteTuplesBatchPassesCollisionIgnoreOptions asserts every
+// Write call carries the collision-ignore options, including on a batch that
+// mixes a genuinely new tuple with one OpenFGA reports as invalid.
+func TestWriteAndDeleteTuplesBatchPassesCollisionIgnoreOptions(t *testing.T) {
+	mockClient := new(MockFgaClient)
+	mockCache := NewMockKeyValue()
+	wantOptions := writeCollisionIgnoreOptions
+
+	mockClient.On("Write", mock.Anything, mock.Anything, wantOptions).
+		Return(&ClientWriteResponse{}, nil).Once()
+
+	service := FgaService{client: mockClient, cacheBucket: mockCache}
+	writes := []ClientTupleKey{{Object: "project:1", Relation: "viewer", User: "user:alice"}}
+
+	_, err := service.writeAndDeleteTuplesBatch(context.Background(), writes, nil)
+
+	assert.NoError(t, err)
+	mockClient.AssertExpectations(t)
+}
+
+// TestWriteAndDeleteTuplesBatchCollisionSucceedsAsNoOp asserts that when
+// OpenFGA (via the collision-ignore options) reports success for a batch
+// that would otherwise collide, the batch is not treated as an error and no
+// tuple is skipped: the collision never reaches this code as an error at
+// all, so extractInvalidTuple's skip path is not exercised.
+func TestWriteAndDeleteTuplesBatchCollisionSucceedsAsNoOp(t *testing.T) {
+	mockClient := new(MockFgaClient)
+	mockCache := NewMockKeyValue()
+
+	mockClient.On("Write", mock.Anything, mock.MatchedBy(func(req ClientWriteRequest) bool {
+		return len(req.Writes) == 1 && len(req.Deletes) == 1
+	}), mock.Anything).Return(&ClientWriteResponse{}, nil).Once()
+
+	service := FgaService{client: mockClient, cacheBucket: mockCache}
+	writes := []ClientTupleKey{{Object: "project:1", Relation: "viewer", User: "user:alice"}}
+	deletes := []ClientTupleKeyWithoutCondition{{Object: "project:1", Relation: "writer", User: "user:bob"}}
+
+	skipped, err := service.writeAndDeleteTuplesBatch(context.Background(), writes, deletes)
+
+	assert.NoError(t, err)
+	assert.Empty(t, skipped)
+	mockClient.AssertExpectations(t)
 }

--- a/handler_access_test.go
+++ b/handler_access_test.go
@@ -282,7 +282,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.MatchedBy(func(req client.ClientWriteRequest) bool {
 					// Should have: public viewer, parent relation, 2 writers = 4 tuples
 					return len(req.Writes) == 4 && len(req.Deletes) == 0
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -312,7 +312,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.MatchedBy(func(req client.ClientWriteRequest) bool {
 					// Should have: 3 references + 7 relations (no public) = 10 tuples
 					return len(req.Writes) == 10 && len(req.Deletes) == 0
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -342,7 +342,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 						}
 					}
 					return true
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -378,7 +378,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 			replySubject: "reply.subject",
 			setupMocks: func(service *HandlerService, msg *MockNatsMsg) {
 				// Mock FGA service to return error
-				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.Anything).Return((*client.ClientWriteResponse)(nil), assert.AnError)
+				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.Anything, mock.Anything).Return((*client.ClientWriteResponse)(nil), assert.AnError)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  true,
@@ -400,7 +400,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 					// Should have only 1 tuple: public viewer
 					return len(req.Writes) == 1 && len(req.Deletes) == 0 &&
 						req.Writes[0].User == "user:*" && req.Writes[0].Relation == "viewer"
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -418,7 +418,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 			replySubject: "",
 			setupMocks: func(service *HandlerService, msg *MockNatsMsg) {
 				// Should not call Respond
-				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.Anything).Return(&client.ClientWriteResponse{}, nil)
+				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -436,7 +436,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 			replySubject: "reply.subject",
 			setupMocks: func(service *HandlerService, msg *MockNatsMsg) {
 				msg.On("Respond", []byte("OK")).Return(assert.AnError).Once()
-				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.Anything).Return(&client.ClientWriteResponse{}, nil)
+				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  true,
@@ -471,7 +471,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.MatchedBy(func(req client.ClientWriteRequest) bool {
 					// Should have: 1 public + 5 references + 15 relations = 21 tuples
 					return len(req.Writes) == 21 && len(req.Deletes) == 0
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -497,7 +497,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 				service.fgaService.client.(*MockFgaClient).On("Write", mock.Anything, mock.MatchedBy(func(req client.ClientWriteRequest) bool {
 					// Should have: 1 parent + 3 relations = 4 tuples (no public)
 					return len(req.Writes) == 4 && len(req.Deletes) == 0
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -536,7 +536,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 						}
 					}
 					return parentCount == 3
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -570,7 +570,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 						}
 					}
 					return committeeCount == 4
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -610,7 +610,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 					}
 					return counts["parent"] == 2 && counts["project"] == 3 &&
 						counts["committee"] == 1 && counts["team"] == 4
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,
@@ -644,7 +644,7 @@ func TestProcessStandardAccessUpdate(t *testing.T) {
 						}
 					}
 					return true
-				})).Return(&client.ClientWriteResponse{}, nil)
+				}), mock.Anything).Return(&client.ClientWriteResponse{}, nil)
 				service.fgaService.client.(*MockFgaClient).On("Read", mock.Anything, mock.Anything, mock.Anything).Return(&client.ClientReadResponse{}, nil)
 			},
 			expectedError:  false,

--- a/handler_generic.go
+++ b/handler_generic.go
@@ -244,44 +244,44 @@ func (h *HandlerService) parseAndValidateMemberPutMessage(
 	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse generic message")
-		return nil, nil, err
+		return nil, nil, newTerminalValidationError(err)
 	}
 
 	// Validate object_type
 	if genericMsg.ObjectType == "" {
 		logger.ErrorContext(ctx, "object_type is required")
-		return nil, nil, errors.New("object_type is required")
+		return nil, nil, newTerminalValidationError(errors.New("object_type is required"))
 	}
 	if genericMsg.Operation != "member_put" {
 		logger.ErrorContext(ctx, "invalid operation for this handler", "operation", genericMsg.Operation)
-		return nil, nil, errors.New("invalid operation for member_put handler")
+		return nil, nil, newTerminalValidationError(errors.New("invalid operation for member_put handler"))
 	}
 
 	// Parse data field
 	data := new(fgatypes.GenericMemberData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse member data")
-		return nil, nil, err
+		return nil, nil, newTerminalValidationError(err)
 	}
 
 	// Validate required fields
 	if data.Username == "" {
 		logger.ErrorContext(ctx, "username is required")
-		return nil, nil, errors.New("username is required")
+		return nil, nil, newTerminalValidationError(errors.New("username is required"))
 	}
 	if data.UID == "" {
 		logger.ErrorContext(ctx, "uid is required")
-		return nil, nil, errors.New("uid is required")
+		return nil, nil, newTerminalValidationError(errors.New("uid is required"))
 	}
 	if len(data.Relations) == 0 {
 		logger.ErrorContext(ctx, "relations array cannot be empty")
-		return nil, nil, errors.New("relations array cannot be empty")
+		return nil, nil, newTerminalValidationError(errors.New("relations array cannot be empty"))
 	}
 	// Validate each relation is non-empty
 	for _, relation := range data.Relations {
 		if relation == "" {
 			logger.ErrorContext(ctx, "relation value cannot be empty")
-			return nil, nil, errors.New("relation value cannot be empty")
+			return nil, nil, newTerminalValidationError(errors.New("relation value cannot be empty"))
 		}
 	}
 
@@ -431,34 +431,34 @@ func (h *HandlerService) genericMemberRemoveHandler(ctx context.Context, message
 	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse generic message")
-		return err
+		return newTerminalValidationError(err)
 	}
 
 	// Validate
 	if genericMsg.ObjectType == "" {
 		logger.ErrorContext(ctx, "object_type is required")
-		return errors.New("object_type is required")
+		return newTerminalValidationError(errors.New("object_type is required"))
 	}
 	if genericMsg.Operation != "member_remove" {
 		logger.ErrorContext(ctx, "invalid operation for this handler", "operation", genericMsg.Operation)
-		return errors.New("invalid operation for member_remove handler")
+		return newTerminalValidationError(errors.New("invalid operation for member_remove handler"))
 	}
 
 	// Parse data field
 	data := new(fgatypes.GenericMemberData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
 		logger.With(errKey, err).ErrorContext(ctx, "failed to parse member data")
-		return err
+		return newTerminalValidationError(err)
 	}
 
 	// Validate required fields
 	if data.Username == "" {
 		logger.ErrorContext(ctx, "username is required")
-		return errors.New("username is required")
+		return newTerminalValidationError(errors.New("username is required"))
 	}
 	if data.UID == "" {
 		logger.ErrorContext(ctx, "uid is required")
-		return errors.New("uid is required")
+		return newTerminalValidationError(errors.New("uid is required"))
 	}
 
 	logger.With(

--- a/handler_generic_test.go
+++ b/handler_generic_test.go
@@ -70,6 +70,79 @@ func TestGenericAccessHandlersMarkLocalValidationErrorsTerminal(t *testing.T) {
 			handler: (*HandlerService).genericDeleteAccessHandler,
 			payload: `{"object_type":"committee","operation":"delete_access","data":{}}`,
 		},
+		{
+			name:    "member_put malformed JSON",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{`,
+		},
+		{
+			name:    "member_put missing object type",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"operation":"member_put","data":{"uid":"resource-1","username":"user-1","relations":["member"]}}`,
+		},
+		{
+			name:    "member_put wrong operation",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"object_type":"committee","operation":"member_remove",` +
+				`"data":{"uid":"resource-1","username":"user-1","relations":["member"]}}`,
+		},
+		{
+			name:    "member_put malformed member data",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"object_type":"committee","operation":"member_put","data":"not-an-object"}`,
+		},
+		{
+			name:    "member_put missing username",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"object_type":"committee","operation":"member_put","data":{"uid":"resource-1","relations":["member"]}}`,
+		},
+		{
+			name:    "member_put missing UID",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"object_type":"committee","operation":"member_put","data":{"username":"user-1","relations":["member"]}}`,
+		},
+		{
+			name:    "member_put empty relations array",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"object_type":"committee","operation":"member_put",` +
+				`"data":{"uid":"resource-1","username":"user-1","relations":[]}}`,
+		},
+		{
+			name:    "member_put empty relation entry",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"object_type":"committee","operation":"member_put",` +
+				`"data":{"uid":"resource-1","username":"user-1","relations":[""]}}`,
+		},
+		{
+			name:    "member_remove malformed JSON",
+			handler: (*HandlerService).genericMemberRemoveHandler,
+			payload: `{`,
+		},
+		{
+			name:    "member_remove missing object type",
+			handler: (*HandlerService).genericMemberRemoveHandler,
+			payload: `{"operation":"member_remove","data":{"uid":"resource-1","username":"user-1"}}`,
+		},
+		{
+			name:    "member_remove wrong operation",
+			handler: (*HandlerService).genericMemberRemoveHandler,
+			payload: `{"object_type":"committee","operation":"member_put","data":{"uid":"resource-1","username":"user-1"}}`,
+		},
+		{
+			name:    "member_remove malformed member data",
+			handler: (*HandlerService).genericMemberRemoveHandler,
+			payload: `{"object_type":"committee","operation":"member_remove","data":"not-an-object"}`,
+		},
+		{
+			name:    "member_remove missing username",
+			handler: (*HandlerService).genericMemberRemoveHandler,
+			payload: `{"object_type":"committee","operation":"member_remove","data":{"uid":"resource-1"}}`,
+		},
+		{
+			name:    "member_remove missing UID",
+			handler: (*HandlerService).genericMemberRemoveHandler,
+			payload: `{"object_type":"committee","operation":"member_remove","data":{"username":"user-1"}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +157,44 @@ func TestGenericAccessHandlersMarkLocalValidationErrorsTerminal(t *testing.T) {
 			if tt.redacted != "" {
 				assert.NotContains(t, err.Error(), tt.redacted)
 			}
+		})
+	}
+}
+
+// TestMemberRemoveEmptyRelationsIsValid asserts that member_remove treats an
+// empty relations array, or one containing only empty strings, as a request
+// to remove every managed relation for that user, and does not mark it terminal.
+func TestMemberRemoveEmptyRelationsIsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "empty relations array",
+			payload: `{"object_type":"committee","operation":"member_remove",` +
+				`"data":{"uid":"resource-1","username":"user-1","relations":[]}}`,
+		},
+		{
+			name: "relations containing only empty strings",
+			payload: `{"object_type":"committee","operation":"member_remove",` +
+				`"data":{"uid":"resource-1","username":"user-1","relations":["",""]}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := setupService()
+			service.fgaService.client.(*MockFgaClient).
+				On("Read", mock.Anything, mock.Anything, client.ClientReadOptions{}).
+				Return(&client.ClientReadResponse{Tuples: nil}, nil)
+
+			err := service.genericMemberRemoveHandler(context.Background(), CreateMockNatsMsg([]byte(tt.payload)))
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -105,6 +216,17 @@ func TestGenericAccessHandlersLeaveFgaErrorsTransient(t *testing.T) {
 			name:    "delete",
 			handler: (*HandlerService).genericDeleteAccessHandler,
 			payload: `{"object_type":"committee","operation":"delete_access","data":{"uid":"resource-1"}}`,
+		},
+		{
+			name:    "member_put",
+			handler: (*HandlerService).genericMemberPutHandler,
+			payload: `{"object_type":"committee","operation":"member_put",` +
+				`"data":{"uid":"resource-1","username":"user-1","relations":["member"]}}`,
+		},
+		{
+			name:    "member_remove",
+			handler: (*HandlerService).genericMemberRemoveHandler,
+			payload: `{"object_type":"committee","operation":"member_remove","data":{"uid":"resource-1","username":"user-1"}}`,
 		},
 	}
 	fgaErrors := []struct {

--- a/main.go
+++ b/main.go
@@ -370,6 +370,13 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 	return nil
 }
 
+// queueSubscriptionConfigs lists core NATS (non-JetStream) subscriptions only.
+// member_put and member_remove moved to the shared JetStream access-mutation
+// consumer in release 2/3 of the fga-sync-jetstream-membership change; do not
+// add them back here. See
+// openspec/changes/fga-sync-jetstream-membership/tasks.md group 7 — this
+// change must not deploy before group 6 (stream widening) is applied and
+// verified live, or membership messages are lost permanently.
 func queueSubscriptionConfigs(handlerService HandlerService) []subscriptionConfig {
 	return []subscriptionConfig{
 		{
@@ -381,16 +388,6 @@ func queueSubscriptionConfigs(handlerService HandlerService) []subscriptionConfi
 			subject:     constants.ReadTuplesSubject,
 			handler:     handlerService.readTuplesHandler,
 			description: "read tuples",
-		},
-		{
-			subject:     constants.GenericMemberPutSubject,
-			handler:     handlerService.genericMemberPutHandler,
-			description: "generic member put",
-		},
-		{
-			subject:     constants.GenericMemberRemoveSubject,
-			handler:     handlerService.genericMemberRemoveHandler,
-			description: "generic member remove",
 		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -372,11 +372,12 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 
 // queueSubscriptionConfigs lists core NATS (non-JetStream) subscriptions only.
 // member_put and member_remove moved to the shared JetStream access-mutation
-// consumer in release 2/3 of the fga-sync-jetstream-membership change; do not
-// add them back here. See docs/runbooks/fga-sync-jetstream-cutover.md
-// (Phase 2, release 3) — this change must not deploy before release 2
-// (stream widening) is applied and verified live, or membership messages are
-// lost permanently.
+// consumer in the fga-sync-jetstream-membership change and are deployed
+// together with the widened stream subjects (see values.yaml
+// accessMutationStream.subjects) in the same release; do not add them back
+// here. See docs/runbooks/fga-sync-jetstream-cutover.md (Phase 2) for the
+// preconditions that gate this deploy and the accepted risk of shipping the
+// stream widening and this removal together.
 func queueSubscriptionConfigs(handlerService HandlerService) []subscriptionConfig {
 	return []subscriptionConfig{
 		{

--- a/main.go
+++ b/main.go
@@ -373,10 +373,10 @@ func createQueueSubscriptions(handlerService HandlerService) error {
 // queueSubscriptionConfigs lists core NATS (non-JetStream) subscriptions only.
 // member_put and member_remove moved to the shared JetStream access-mutation
 // consumer in release 2/3 of the fga-sync-jetstream-membership change; do not
-// add them back here. See
-// openspec/changes/fga-sync-jetstream-membership/tasks.md group 7 — this
-// change must not deploy before group 6 (stream widening) is applied and
-// verified live, or membership messages are lost permanently.
+// add them back here. See docs/runbooks/fga-sync-jetstream-cutover.md
+// (Phase 2, release 3) — this change must not deploy before release 2
+// (stream widening) is applied and verified live, or membership messages are
+// lost permanently.
 func queueSubscriptionConfigs(handlerService HandlerService) []subscriptionConfig {
 	return []subscriptionConfig{
 		{

--- a/mock.go
+++ b/mock.go
@@ -37,8 +37,9 @@ func (m *MockFgaClient) Read(
 func (m *MockFgaClient) Write(
 	ctx context.Context,
 	req ClientWriteRequest,
+	options ClientWriteOptions,
 ) (*ClientWriteResponse, error) {
-	args := m.Called(ctx, req)
+	args := m.Called(ctx, req, options)
 	//nolint:errcheck // the error is passed through to the caller
 	return args.Get(0).(*ClientWriteResponse), args.Error(1)
 }


### PR DESCRIPTION
## Summary

Phase 2 of the JetStream migration (Jira: LFXV2-2831). Moves `member_put`/`member_remove` onto the same durable JetStream consumer already carrying `update_access`/`delete_access`, in three internally-ordered releases:

- **Release 1 (code, inert until release 2):** shared consumer dispatch + `FilterSubjects` for all four subjects; proven-invalid membership payloads (missing `username`/`uid`, malformed JSON, wrong operation, empty relation entries) now terminate instead of retrying; `on_duplicate: ignore` / `on_missing: ignore` passed to every OpenFGA write so a message applied twice during the planned overlap window is a no-op, not an error.
- **Release 2 (Helm):** widens the `fga-sync-events` stream's `subjects` to include the two membership subjects.
- **Release 3 (code):** removes the core NATS subscriptions for the two membership subjects, making JetStream the sole delivery path.
- **Docs:** `docs/fga-sync-contract.md`, `docs/client-guide.md`, and `docs/runbooks/fga-sync-jetstream-cutover.md` updated for the new async-only, terminal-vs-transient delivery semantics, plus a new Phase 2 cutover/rollback runbook section.

**Deploy ordering is NOT enforced by this commit** — it's enforced by when the Helm rollout actually applies the stream-widening change and when the core-subscription-removal build gets deployed. Release 2 must not go live until the four owning publisher services are confirmed asynchronous-only for these two subjects (LFXV2-2830, LFXV2-2828, member-service PR #82, committee-service PR #164, LFXV2-2890). Release 3 must not go live before release 2 is confirmed live, or membership messages are lost permanently. See `openspec/changes/fga-sync-jetstream-membership/tasks.md` groups 5-7 for the full gating checklist.
The below PR's should get merged before this PR
PR - https://github.com/linuxfoundation/lfx-v2-committee-service/pull/164
PR - https://github.com/linuxfoundation/lfx-v2-member-service/pull/82

## Evidence

- `make test`, `make check` (fmt/vet/lint), and `go test -race ./...` all pass clean.
- `openspec validate fga-sync-jetstream-membership --strict` reports the change as valid.
- No hardcoded subject strings introduced outside `pkg/constants`.
- **Live JetStream test** against a real local `nats-server` (v2.14.2, not a mocked NATS connection) — all test data below is synthetic placeholder data (object type `committee`, UIDs `<placeholder>-1`/`-2`/`-3`, username `<placeholder>`), not real production identifiers:
  - Stream widened to all four subjects; the real durable consumer picked up the production `FilterSubjects` config for all four subjects.
  - Valid `member_put`/`member_remove` delivered and ACKed through the real JetStream pipeline.
  - A `member_put` missing the required username field was **terminated**, not redelivered.
  - `update_access`/`delete_access` delivery on the shared consumer was unaffected.
  - The write-collision-ignore options were confirmed reaching the FGA client on a live-delivered message (not just asserted in a unit test).
  - Consumer ended with zero ack-pending — no stuck deliveries.
- Two review findings from an automated diff review were investigated and refuted/contextualized with fresh empirical evidence (not just re-asserted): a claimed `FilterSubjects`-superset consumer-creation failure was reproduced against a real `nats-server` and did not occur (confirmed against NATS server source: the relevant error is a wildcard-token subset check, not a "subject entirely absent from stream" check); a claimed unintended double-processing risk is real as a mechanism but is the deliberately designed and already-mitigated release-2/3 overlap window (write-collision-ignore options exist specifically for this).

## Test plan

- [x] `make test`
- [x] `make check`
- [x] `go test -race ./...`
- [x] `openspec validate fga-sync-jetstream-membership --strict`
- [x] Live local JetStream test (see Evidence)