### PR TITLE
fix(handler): remove duplicate logs and downgrade member_remove validation to single ERROR

### DIFF
--- a/access_mutation.go
+++ b/access_mutation.go
@@ -472,6 +472,7 @@ func logAccessMutationFailure(
 	attributes := append([]any{
 		"error_type", safeErrorType(err),
 		"classification", classification,
+		errKey, err,
 	}, accessMutationDeliveryAttributes(message)...)
 	logger.With(attributes...).ErrorContext(ctx, "access mutation delivery failure")
 }

--- a/handler_generic.go
+++ b/handler_generic.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
 	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
@@ -430,35 +431,30 @@ func (h *HandlerService) genericMemberRemoveHandler(ctx context.Context, message
 	// Parse generic message
 	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
-		logger.With(errKey, err).WarnContext(ctx, "failed to parse generic message")
-		return newTerminalValidationError(err)
+		return newTerminalValidationError(fmt.Errorf("failed to parse generic message: %w", err))
 	}
 
 	// Validate
 	if genericMsg.ObjectType == "" {
-		logger.WarnContext(ctx, "object_type is required")
-		return newTerminalValidationError(errors.New("object_type is required"))
+		return newTerminalValidationError(errors.New("member_remove: object_type is required"))
 	}
 	if genericMsg.Operation != "member_remove" {
-		logger.WarnContext(ctx, "invalid operation for this handler", "operation", genericMsg.Operation)
-		return newTerminalValidationError(errors.New("invalid operation for member_remove handler"))
+		return newTerminalValidationError(
+			fmt.Errorf("member_remove: invalid operation %q", genericMsg.Operation))
 	}
 
 	// Parse data field
 	data := new(fgatypes.GenericMemberData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
-		logger.With(errKey, err).WarnContext(ctx, "failed to parse member data")
-		return newTerminalValidationError(err)
+		return newTerminalValidationError(fmt.Errorf("member_remove: failed to parse member data: %w", err))
 	}
 
 	// Validate required fields
 	if data.Username == "" {
-		logger.WarnContext(ctx, "username is required")
-		return newTerminalValidationError(errors.New("username is required"))
+		return newTerminalValidationError(errors.New("member_remove: username is required"))
 	}
 	if data.UID == "" {
-		logger.WarnContext(ctx, "uid is required")
-		return newTerminalValidationError(errors.New("uid is required"))
+		return newTerminalValidationError(errors.New("member_remove: uid is required"))
 	}
 
 	logger.With(

--- a/handler_generic.go
+++ b/handler_generic.go
@@ -430,34 +430,34 @@ func (h *HandlerService) genericMemberRemoveHandler(ctx context.Context, message
 	// Parse generic message
 	genericMsg := new(fgatypes.GenericFGAMessage)
 	if err := json.Unmarshal(message.Data(), genericMsg); err != nil {
-		logger.With(errKey, err).ErrorContext(ctx, "failed to parse generic message")
+		logger.With(errKey, err).WarnContext(ctx, "failed to parse generic message")
 		return newTerminalValidationError(err)
 	}
 
 	// Validate
 	if genericMsg.ObjectType == "" {
-		logger.ErrorContext(ctx, "object_type is required")
+		logger.WarnContext(ctx, "object_type is required")
 		return newTerminalValidationError(errors.New("object_type is required"))
 	}
 	if genericMsg.Operation != "member_remove" {
-		logger.ErrorContext(ctx, "invalid operation for this handler", "operation", genericMsg.Operation)
+		logger.WarnContext(ctx, "invalid operation for this handler", "operation", genericMsg.Operation)
 		return newTerminalValidationError(errors.New("invalid operation for member_remove handler"))
 	}
 
 	// Parse data field
 	data := new(fgatypes.GenericMemberData)
 	if err := genericMsg.UnmarshalData(data); err != nil {
-		logger.With(errKey, err).ErrorContext(ctx, "failed to parse member data")
+		logger.With(errKey, err).WarnContext(ctx, "failed to parse member data")
 		return newTerminalValidationError(err)
 	}
 
 	// Validate required fields
 	if data.Username == "" {
-		logger.ErrorContext(ctx, "username is required")
+		logger.WarnContext(ctx, "username is required")
 		return newTerminalValidationError(errors.New("username is required"))
 	}
 	if data.UID == "" {
-		logger.ErrorContext(ctx, "uid is required")
+		logger.WarnContext(ctx, "uid is required")
 		return newTerminalValidationError(errors.New("uid is required"))
 	}
 


### PR DESCRIPTION
## Summary

- Validation failures in \`genericMemberRemoveHandler\` (missing \`object_type\`, wrong \`operation\`, unparseable data, missing \`username\`, missing \`uid\`) were previously emitting two log lines per bad message: an inner \`ErrorContext\`/\`WarnContext\` with the specific reason, and an outer \`ErrorContext\` from \`logAccessMutationFailure\` with JetStream delivery context — but without the error message.
- Fix by removing all inner log calls from the handler and prefixing the error strings with \`member_remove:\` so the source handler is self-evident from the error message alone.
- Extend \`logAccessMutationFailure\` to include \`errKey, err\` so the actual error message (e.g. \`"member_remove: username is required"\`) appears in the single outer ERROR alongside \`stream_sequence\`, \`delivery_count\`, and \`object_type\`.

**Result:** one ERROR per bad message with full context, instead of two partially-overlapping log lines. \`logAccessMutationFailure\` is shared by all JetStream handlers, so \`update_access\`, \`delete_access\`, and \`member_put\` also benefit.

## Context

Identified during an audit of \`member_remove\` publishers across the platform (LFXV2-3081). The audit found that \`lfx-v2-member-service\`'s CDC consumer (\`cdc_consumer.go\`) intentionally publishes \`member_remove\` with an empty username on key-contact deletes, relying on a fga-sync cleanup-by-object-id behaviour that does not exist — that is the primary source of the "username is required" warnings seen in production, and requires a separate fix in \`lfx-v2-member-service\`.

Refs: LFXV2-3081

Made with [Cursor](https://cursor.com)