### PR TITLE
feat(constants): add marketing-ops relation constants

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -89,7 +89,8 @@
     "cutover",
     "Cutover",
     "LFXV",
-    "undispositioned"
+    "undispositioned",
+    "stakater"
   ],
   "overrides": [
     {

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -16,6 +16,10 @@ const (
 	RelationAuditor            = "auditor"
 	RelationMeetingCoordinator = "meeting_coordinator"
 	RelationViewer             = "viewer"
+	RelationExecutiveDirector  = "executive_director"
+	RelationMarketingOps       = "marketing_ops"
+	RelationMarketingAuditor   = "marketing_auditor"
+	RelationCampaignManager    = "campaign_manager"
 
 	// Meeting relations
 	RelationProject                       = "project"

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -22,8 +22,6 @@ const (
 	// emission path and must be granted via the team-based workflow instead.
 	RelationMarketingOps     = "marketing_ops"
 	RelationMarketingAuditor = "marketing_auditor"
-	// campaign_manager is a computed relation (executive_director or marketing_ops) with no
-	// direct tuple accepted — intentionally no RelationCampaignManager constant here.
 
 	// Meeting relations
 	RelationProject                       = "project"

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -17,9 +17,13 @@ const (
 	RelationMeetingCoordinator = "meeting_coordinator"
 	RelationViewer             = "viewer"
 	RelationExecutiveDirector  = "executive_director"
-	RelationMarketingOps       = "marketing_ops"
-	RelationMarketingAuditor   = "marketing_auditor"
-	RelationCampaignManager    = "campaign_manager"
+	// RelationMarketingOps and RelationMarketingAuditor only accept [team#member] tuples
+	// in the model, not [user] — they cannot go through the generic per-user obj.Relations
+	// emission path and must be granted via the team-based workflow instead.
+	RelationMarketingOps     = "marketing_ops"
+	RelationMarketingAuditor = "marketing_auditor"
+	// campaign_manager is a computed relation (executive_director or marketing_ops) with no
+	// direct tuple accepted — intentionally no RelationCampaignManager constant here.
 
 	// Meeting relations
 	RelationProject                       = "project"

--- a/pkg/constants/fga.go
+++ b/pkg/constants/fga.go
@@ -17,11 +17,6 @@ const (
 	RelationMeetingCoordinator = "meeting_coordinator"
 	RelationViewer             = "viewer"
 	RelationExecutiveDirector  = "executive_director"
-	// RelationMarketingOps and RelationMarketingAuditor only accept [team#member] tuples
-	// in the model, not [user] — they cannot go through the generic per-user obj.Relations
-	// emission path and must be granted via the team-based workflow instead.
-	RelationMarketingOps     = "marketing_ops"
-	RelationMarketingAuditor = "marketing_auditor"
 
 	// Meeting relations
 	RelationProject                       = "project"


### PR DESCRIPTION
## Summary
- Adds `RelationExecutiveDirector`, `RelationMarketingOps`, `RelationMarketingAuditor`, and `RelationCampaignManager` to `pkg/constants/fga.go`, matching the relations already defined on `type project` in the OpenFGA model (`lfx-v2-helm/charts/lfx-platform/files/model.fga`).
- No handler changes needed: `processStandardAccessUpdate` iterates `obj.Relations` generically, so these relations sync automatically once a resource service starts emitting them.

Part of LFXV2-2231 (Global Marketing Ops role & permissions epic).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `make fmt`
- [x] `golangci-lint run ./...`

LFXV2-2234