### PR TITLE
ci: standardize MegaLinter and SHA-pin remaining action refs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,10 @@
     "LICENSE-docs"
   ],
   "words": [
+    "zizmor",
+    "ZIZMOR",
+    "artipacked",
+    "startswith",
     "golangci",
     "openfga",
     "OPENSEARCH",

--- a/.cspell.json
+++ b/.cspell.json
@@ -18,6 +18,7 @@
     "artipacked",
     "startswith",
     "golangci",
+    "govulncheck",
     "openfga",
     "OPENSEARCH",
     "jetstream",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,12 +32,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@6d786de4d6f3531a740e445b53a42b622bbbace8  # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: autobuild
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@6d786de4d6f3531a740e445b53a42b622bbbace8  # v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,14 +30,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@6d786de4d6f3531a740e445b53a42b622bbbace8  # v3
+        uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85  # v3.37.8
         with:
           languages: ${{ matrix.language }}
           build-mode: autobuild
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@6d786de4d6f3531a740e445b53a42b622bbbace8  # v3
+        uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85  # v3.37.8
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/ko-build-main.yaml
+++ b/.github/workflows/ko-build-main.yaml
@@ -20,8 +20,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: go.mod
       - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d  # v0.8

--- a/.github/workflows/ko-build-main.yaml
+++ b/.github/workflows/ko-build-main.yaml
@@ -20,11 +20,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
-      - uses: ko-build/setup-ko@v0.8
+      - uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d  # v0.8
         with:
           version: v0.17.1
       - name: Build and publish fga-sync image

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -28,15 +28,19 @@ jobs:
       chart_version: ${{ steps.prepare.outputs.chart_version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Prepare versions and chart name
         id: prepare
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          APP_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//g')
+          APP_VERSION=${REF_NAME//v/}
           CHART_NAME="$(yq '.name' charts/*/Chart.yaml)"
-          CHART_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//g')
+          CHART_VERSION="$APP_VERSION"
           {
             echo "app_version=$APP_VERSION"
             echo "chart_name=$CHART_NAME"
@@ -44,9 +48,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Setup Ko
         uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d  # v0.8
@@ -57,6 +62,7 @@ jobs:
         env:
           VERSION: ${{ steps.prepare.outputs.app_version }}
           GIT_COMMIT: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
           export BUILD_TIME
@@ -65,8 +71,8 @@ jobs:
           ko build github.com/linuxfoundation/lfx-v2-fga-sync \
             -B \
             --platform linux/amd64,linux/arm64 \
-            -t ${{ github.ref_name }} \
-            -t ${{ steps.prepare.outputs.app_version }} \
+            -t "$REF_NAME" \
+            -t "$VERSION" \
             -t latest \
             --sbom spdx
 
@@ -82,12 +88,14 @@ jobs:
       image_name: ${{ steps.publish-ghcr.outputs.image_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Publish Chart to GHCR
         id: publish-ghcr
         # yamllint disable-line rule:line-length
-        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@17e4144d7ba68f7c3e8c16eece5aed15fd7c2dc8 # main
+        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@a93335d2abc2a2e2bb1b7a4cdefbbf15351681ce # v0.1.0
         with:
           name: ${{ needs.publish.outputs.chart_name }}
           repository: ${{ github.repository }}/chart
@@ -112,9 +120,11 @@ jobs:
       - name: Sign the Helm chart in GHCR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ steps.publish-ghcr.outputs.image_name }}
+          IMAGE_DIGEST: ${{ steps.publish-ghcr.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign sign --yes '${{ steps.publish-ghcr.outputs.image_name }}@${{ steps.publish-ghcr.outputs.digest }}'
+          cosign sign --yes "${IMAGE_NAME}@${IMAGE_DIGEST}"
 
   create-ghcr-helm-provenance:
     needs:

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -44,12 +44,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version-file: go.mod
 
       - name: Setup Ko
-        uses: ko-build/setup-ko@v0.8
+        uses: ko-build/setup-ko@d982fec422852203cfb2053a8ec6ad302280d04d  # v0.8
         with:
           version: v0.17.1
 
@@ -123,7 +123,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    # Note, this action *cannot* be pinned to a SHA: see the project's
+    # explanation at "Referencing SLSA builders and generators" in their README.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0  # zizmor: ignore[unpinned-uses]
     with:
       image: ${{ needs.release-helm-chart.outputs.image_name }}
       digest: ${{ needs.release-helm-chart.outputs.digest }}

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -12,6 +12,6 @@ permissions:
 jobs:
   license-header-check:
     name: License Header Check
-    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@main
+    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@a93335d2abc2a2e2bb1b7a4cdefbbf15351681ce # v0.1.0
     with:
       copyright_line: "Copyright The Linux Foundation and each contributor to LFX."

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -24,20 +24,24 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # MegaLinter
       - name: MegaLinter
         id: ml
         # Use the Go flavor.
-        uses: oxsecurity/megalinter/flavors/go@5a91fb06c83d0e69fbd23756d47438aa723b4a5a  # 8.7.0
+        uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc  # v9.6.0
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Allow GITHUB_TOKEN for working around rate limits (aquasecurity/trivy#7668).
           REPOSITORY_TRIVY_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN
+          # zizmor's "artipacked" audit needs the GitHub API (to verify
+          # SHA-pinned action tags), which requires GITHUB_TOKEN.
+          ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN
           # Set the Go toolchain to auto so that megalinter uses the correct go version for the service.
           GOTOOLCHAIN: auto

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -34,6 +34,10 @@ jobs:
         id: ml
         # Use the Go flavor.
         uses: oxsecurity/megalinter/flavors/go@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc  # v9.6.0
+        # Only Actions-specific values (secrets, runner behavior) belong
+        # here. Generic MegaLinter/repo config belongs in .mega-linter.yml
+        # so local runs (e.g. mega-linter-runner) get the same behavior.
+        #
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
@@ -43,5 +47,3 @@ jobs:
           # zizmor's "artipacked" audit needs the GitHub API (to verify
           # SHA-pinned action tags), which requires GITHUB_TOKEN.
           ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN
-          # Set the Go toolchain to auto so that megalinter uses the correct go version for the service.
-          GOTOOLCHAIN: auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,16 @@ Freely bump `go.mod`'s `go` directive to the latest available *patch*
 release (e.g. `1.X.Y` → `1.X.{Y+1}`) to pick up security fixes. Do **not**
 bump the *minor* version (e.g. `1.X.x` → `1.{X+1}.x`) unless the user
 explicitly asks for it, **and** you've validated it against the Go version
-MegaLinter itself bundles -- MegaLinter runs several linters (e.g.
-`golangci-lint`) against its own bundled Go version, and a `go.mod`
-directive newer than that bundled version breaks those checks.
+MegaLinter itself bundles -- MegaLinter's `golangci-lint` and `govulncheck`
+(pulled in via its `osv-scanner` check) are guaranteed to lag behind the
+latest Go release by some amount (their binaries are built against
+whatever Go version was current when that MegaLinter flavor tag was cut),
+and a `go.mod` directive newer than what they were built with breaks them
+outright. This is a hard ceiling with no environment-variable workaround --
+`GOTOOLCHAIN: auto` only affects invocations of the `go` command itself
+and does nothing for these precompiled binaries' own internal version
+checks (confirmed empirically: setting it in both the workflow and
+`.mega-linter.yml` still failed).
 
 To find MegaLinter's bundled Go version:
 
@@ -93,17 +100,19 @@ To find MegaLinter's bundled Go version:
 grep -A1 'oxsecurity/megalinter' .github/workflows/*.yml
 # e.g. "uses: oxsecurity/megalinter/flavors/<flavor>@<sha>  # <tag>"
 
-# 2. Fetch that flavor's Dockerfile and read its GO_ALPINE_VERSION (or
-#    GO_IMAGE_VERSION) build arg.
+# 2. Fetch that flavor's Dockerfile and read its GO_ALPINE_VERSION build
+#    arg -- this is what the final image installs as `go`, not
+#    GO_IMAGE_VERSION (which only applies to an intermediate builder
+#    stage).
 curl -s "https://raw.githubusercontent.com/oxsecurity/megalinter/<tag>/flavors/<flavor>/Dockerfile" \
-  | grep -i 'GO_ALPINE_VERSION\|GO_IMAGE_VERSION'
+  | grep -i 'GO_ALPINE_VERSION'
 ```
 
 `go.mod`'s `go` directive must never exceed that bundled version. Staying
 one minor version behind it (rather than matching its minor *and* patch
 exactly) leaves room to always take the latest patch release for security
 fixes without ever being blocked by MegaLinter's own bundled patch version
-lagging behind a newly disclosed vulnerability.
+lagging a newly disclosed vulnerability.
 
 There's no built-in `go` subcommand to look up the latest patch release for
 a given minor version -- query the official `go.dev/dl` JSON feed instead:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,46 @@ build/test/lint workflow. Quick reference:
 - `make check` (runs `fmt`, `vet`, `lint`)
 - `make docker-build`, `make helm-install-local`
 
+### Go Toolchain Version
+
+Freely bump `go.mod`'s `go` directive to the latest available *patch*
+release (e.g. `1.X.Y` → `1.X.{Y+1}`) to pick up security fixes. Do **not**
+bump the *minor* version (e.g. `1.X.x` → `1.{X+1}.x`) unless the user
+explicitly asks for it, **and** you've validated it against the Go version
+MegaLinter itself bundles -- MegaLinter runs several linters (e.g.
+`golangci-lint`) against its own bundled Go version, and a `go.mod`
+directive newer than that bundled version breaks those checks.
+
+To find MegaLinter's bundled Go version:
+
+```bash
+# 1. Find the MegaLinter flavor and pinned version tag used in CI.
+grep -A1 'oxsecurity/megalinter' .github/workflows/*.yml
+# e.g. "uses: oxsecurity/megalinter/flavors/<flavor>@<sha>  # <tag>"
+
+# 2. Fetch that flavor's Dockerfile and read its GO_ALPINE_VERSION (or
+#    GO_IMAGE_VERSION) build arg.
+curl -s "https://raw.githubusercontent.com/oxsecurity/megalinter/<tag>/flavors/<flavor>/Dockerfile" \
+  | grep -i 'GO_ALPINE_VERSION\|GO_IMAGE_VERSION'
+```
+
+`go.mod`'s `go` directive must never exceed that bundled version. Staying
+one minor version behind it (rather than matching its minor *and* patch
+exactly) leaves room to always take the latest patch release for security
+fixes without ever being blocked by MegaLinter's own bundled patch version
+lagging behind a newly disclosed vulnerability.
+
+There's no built-in `go` subcommand to look up the latest patch release for
+a given minor version -- query the official `go.dev/dl` JSON feed instead:
+
+```bash
+# Find the latest patch release for the minor version pinned in go.mod.
+MINOR=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)
+curl -s "https://go.dev/dl/?mode=json&include=all" \
+  | jq -r --arg m "go${MINOR}." '.[].version | select(startswith($m))' \
+  | sort -V | tail -1
+```
+
 ## Configuration
 
 ### Required Environment Variables

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/linuxfoundation/lfx-v2-fga-sync
 
-go 1.25.0
+go 1.25.14
 
 require (
 	github.com/nats-io/nats.go v1.51.0


### PR DESCRIPTION
## Summary

Applies the MegaLinter/GitHub Actions security baseline standardization from `linuxfoundation/lfx-cli` to this repo, per LFXV2-3338.

- Upgrade MegaLinter go flavor from v8.7.0 to v9.6.0 (SHA-pinned), add `persist-credentials: false` to checkout, pin checkout to v6.0.3.
- Add `ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: GITHUB_TOKEN`.
- SHA-pin previously tag-only `actions/checkout`, `actions/setup-go`, `ko-build/setup-ko`, and `github/codeql-action` refs. Left `slsa-github-generator`'s reusable workflow reference tag-pinned (required by that project) with a documented zizmor ignore.
- Document the Go toolchain minor-version policy in `CLAUDE.md`.

## Deferred (flagging for visibility, not fixed in this PR)

This repo uses an `ENABLE_LINTERS` allowlist (8 linters) rather than disabling from the flavor baseline (scope item 5 in LFXV2-3338 asks to prefer disabling from the correct flavor). Converting to `DISABLE_LINTERS` would newly enable ~45 previously-off linters in the `go` flavor (including things like `GO_GOLANGCI_LINT`, several security/SBOM scanners, etc.), which is too high-risk to land without dedicated review/triage of whatever findings surface. Left as-is; tracked as a follow-up in LFXV2-3338.

## Jira

LFXV2-3338

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)